### PR TITLE
fix(security): OAuth redirect validation, CSP, and message validation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -96,5 +96,9 @@
     "32": "assets/icon-32.png",
     "48": "assets/icon-48.png",
     "128": "assets/icon-128.png"
+  },
+
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'; default-src 'self'"
   }
 }

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -298,6 +298,10 @@ async function connectWebSocket(streamerUsername: string): Promise<void> {
   wsConnection.onmessage = (event) => {
     try {
       const message = JSON.parse(event.data);
+      if (!message || typeof message !== 'object' || typeof message.type !== 'string') {
+        console.warn('[AllChat] Ignoring WebSocket message with invalid structure');
+        return;
+      }
       handleWebSocketMessage(message);
     } catch (error) {
       console.error('[AllChat] Failed to parse WebSocket message:', error);

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -649,7 +649,13 @@ async function openAuthTab(platform: string, streamerUsername?: string): Promise
     if (changeInfo.status !== 'complete') return;
 
     const url = updatedTab.url ?? '';
-    if (!url.includes('allch.at/chat/auth-success')) return;
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(url);
+    } catch {
+      return;
+    }
+    if (parsedUrl.hostname !== 'allch.at' || !parsedUrl.pathname.startsWith('/chat/auth-success')) return;
 
     // Stop watching immediately to avoid duplicate handling
     chrome.tabs.onUpdated.removeListener(listener);

--- a/src/ui/components/ChatContainer.tsx
+++ b/src/ui/components/ChatContainer.tsx
@@ -330,7 +330,12 @@ export default function ChatContainer({ platform, streamer, displayName, twitchC
       window.parent.postMessage({ type: 'GET_CONNECTION_STATE' }, '*');
       console.log('[AllChat UI] Requested current connection state');
 
+      const extensionOrigin = new URL(chrome.runtime.getURL('')).origin;
       const messageHandler = (event: MessageEvent) => {
+        // Only accept messages from our own extension origin
+        if (event.origin !== extensionOrigin && event.origin !== window.location.origin) {
+          return;
+        }
         handleIncomingMessage(event.data as Record<string, unknown>);
       };
       window.addEventListener('message', messageHandler);


### PR DESCRIPTION
## Summary

- **H-2**: Fix OAuth redirect URL validation — replace substring `includes()` with proper `URL` hostname + pathname check to prevent redirect spoofing
- **H-3**: Add Content Security Policy to `manifest.json` (`script-src 'self'; object-src 'self'`)
- **M-2**: Add origin validation to in-page iframe `postMessage` receiver in ChatContainer
- **M-7**: Validate WebSocket message structure (require object with string `type` field) before broadcasting to content scripts

## Test plan

- [x] TypeScript compiles clean (`tsc --noEmit`)
- [ ] Load extension unpacked, verify CSP active in DevTools
- [ ] Test OAuth login flow on Twitch/YouTube/Kick — verify token extraction still works
- [ ] Verify chat messages render correctly in in-page and pop-out modes

**Companion PRs:**
- caesarakalaeii/all-chat — Application security hardening
- caesarakalaeii/caesar-deployment — Kubernetes security hardening