### PR TITLE
fix(security): remove localhost from host_permissions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -27,7 +27,6 @@
     "https://www.youtube.com/*",
     "https://studio.youtube.com/*",
     "https://kick.com/*",
-    "http://localhost:8080/*",
     "https://allch.at/*"
   ],
 


### PR DESCRIPTION
Removes localhost:8080 from manifest host_permissions for production.