### PR TITLE
fix(firefox): resolve iframe storage hang and postMessage rejection

### DIFF
--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -13,7 +13,18 @@ export { DEFAULT_SETTINGS };
  */
 export async function getSyncStorage(): Promise<SyncStorage> {
   return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      console.warn('[AllChat Storage] chrome.storage.sync.get timed out, resolving defaults');
+      resolve({ ...DEFAULT_SETTINGS } as SyncStorage);
+    }, 5000);
+
     chrome.storage.sync.get(DEFAULT_SETTINGS as unknown as Record<string, unknown>, (items) => {
+      clearTimeout(timer);
+      if (chrome.runtime.lastError) {
+        console.warn('[AllChat Storage] chrome.storage.sync.get error:', chrome.runtime.lastError.message);
+        resolve({ ...DEFAULT_SETTINGS } as SyncStorage);
+        return;
+      }
       const result = items as unknown as SyncStorage & { extensionEnabled?: boolean };
 
       // Migration: legacy extensionEnabled -> platformEnabled
@@ -64,7 +75,18 @@ export async function setSyncStorage(data: Partial<SyncStorage>): Promise<void> 
  */
 export async function getLocalStorage(): Promise<LocalStorage> {
   return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      console.warn('[AllChat Storage] chrome.storage.local.get timed out, resolving empty');
+      resolve({} as LocalStorage);
+    }, 5000);
+
     chrome.storage.local.get(null, (items) => {
+      clearTimeout(timer);
+      if (chrome.runtime.lastError) {
+        console.warn('[AllChat Storage] chrome.storage.local.get error:', chrome.runtime.lastError.message);
+        resolve({} as LocalStorage);
+        return;
+      }
       resolve(items as LocalStorage);
     });
   });

--- a/src/ui/components/ChatContainer.tsx
+++ b/src/ui/components/ChatContainer.tsx
@@ -330,10 +330,11 @@ export default function ChatContainer({ platform, streamer, displayName, twitchC
       window.parent.postMessage({ type: 'GET_CONNECTION_STATE' }, '*');
       console.log('[AllChat UI] Requested current connection state');
 
-      const extensionOrigin = new URL(chrome.runtime.getURL('')).origin;
       const messageHandler = (event: MessageEvent) => {
-        // Only accept messages from our own extension origin
-        if (event.origin !== extensionOrigin && event.origin !== window.location.origin) {
+        // Only accept messages from the direct parent frame (content script relay).
+        // Origin-based checks fail in Firefox: content scripts report the page origin,
+        // not the extension origin, so all relayed messages get silently dropped.
+        if (event.source !== window.parent) {
           return;
         }
         handleIncomingMessage(event.data as Record<string, unknown>);

--- a/tests/test-firefox-iframe-compat.spec.ts
+++ b/tests/test-firefox-iframe-compat.spec.ts
@@ -1,0 +1,120 @@
+import { test, expect } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const STORAGE_PATH = path.resolve(__dirname, '../src/lib/storage.ts');
+const CHAT_CONTAINER_PATH = path.resolve(__dirname, '../src/ui/components/ChatContainer.tsx');
+
+test.describe('Firefox iframe compatibility — Issue #35', () => {
+
+  test.describe('Bug 1: storage timeout + lastError guard', () => {
+    let storageSrc: string;
+
+    test.beforeAll(() => {
+      storageSrc = fs.readFileSync(STORAGE_PATH, 'utf8');
+    });
+
+    test('getLocalStorage has a setTimeout fallback', () => {
+      // Extract the getLocalStorage function body
+      const fnMatch = storageSrc.match(
+        /export async function getLocalStorage[\s\S]*?^}/m
+      );
+      expect(fnMatch, 'getLocalStorage function must exist').toBeTruthy();
+      const fnBody = fnMatch![0];
+      expect(fnBody).toContain('setTimeout');
+      expect(fnBody).toContain('clearTimeout');
+    });
+
+    test('getLocalStorage checks chrome.runtime.lastError', () => {
+      const fnMatch = storageSrc.match(
+        /export async function getLocalStorage[\s\S]*?^}/m
+      );
+      const fnBody = fnMatch![0];
+      expect(fnBody).toContain('chrome.runtime.lastError');
+    });
+
+    test('getLocalStorage resolves empty on timeout (not reject)', () => {
+      const fnMatch = storageSrc.match(
+        /export async function getLocalStorage[\s\S]*?^}/m
+      );
+      const fnBody = fnMatch![0];
+      // Should resolve with empty object, not reject
+      expect(fnBody).toContain('resolve({} as LocalStorage)');
+      expect(fnBody).not.toContain('reject');
+    });
+
+    test('getSyncStorage has a setTimeout fallback', () => {
+      const fnMatch = storageSrc.match(
+        /export async function getSyncStorage[\s\S]*?^}/m
+      );
+      expect(fnMatch, 'getSyncStorage function must exist').toBeTruthy();
+      const fnBody = fnMatch![0];
+      expect(fnBody).toContain('setTimeout');
+      expect(fnBody).toContain('clearTimeout');
+    });
+
+    test('getSyncStorage checks chrome.runtime.lastError', () => {
+      const fnMatch = storageSrc.match(
+        /export async function getSyncStorage[\s\S]*?^}/m
+      );
+      const fnBody = fnMatch![0];
+      expect(fnBody).toContain('chrome.runtime.lastError');
+    });
+
+    test('getSyncStorage resolves defaults on timeout (not reject)', () => {
+      const fnMatch = storageSrc.match(
+        /export async function getSyncStorage[\s\S]*?^}/m
+      );
+      const fnBody = fnMatch![0];
+      // Should resolve with defaults, not reject
+      expect(fnBody).toContain('DEFAULT_SETTINGS');
+      expect(fnBody).not.toContain('reject');
+    });
+
+    test('timeout is 5000ms for both storage functions', () => {
+      // Both timeouts should be 5000ms — the arrow function spans multiple lines,
+      // so match setTimeout(..., NNNN) with dotAll
+      const timeoutMatches = storageSrc.match(/setTimeout\([\s\S]*?,\s*(\d+)\s*\)/g);
+      expect(timeoutMatches, 'should have setTimeout calls').toBeTruthy();
+      expect(timeoutMatches!.length).toBeGreaterThanOrEqual(2);
+      for (const match of timeoutMatches!) {
+        const ms = match.match(/,\s*(\d+)\s*\)$/);
+        expect(ms).toBeTruthy();
+        expect(Number(ms![1])).toBe(5000);
+      }
+    });
+  });
+
+  test.describe('Bug 2: postMessage source check replaces origin check', () => {
+    let containerSrc: string;
+
+    test.beforeAll(() => {
+      containerSrc = fs.readFileSync(CHAT_CONTAINER_PATH, 'utf8');
+    });
+
+    test('message handler uses event.source === window.parent', () => {
+      expect(containerSrc).toContain('event.source !== window.parent');
+    });
+
+    test('message handler does NOT use origin-based check for incoming messages', () => {
+      // The in-page iframe message handler should not compare event.origin
+      // (origin checks fail in Firefox because content scripts report page origin)
+      // Note: only check the messageHandler section, not the entire file
+      const handlerMatch = containerSrc.match(
+        /const messageHandler = \(event: MessageEvent\)[\s\S]*?window\.addEventListener\('message', messageHandler\)/
+      );
+      expect(handlerMatch, 'messageHandler must exist').toBeTruthy();
+      const handlerBody = handlerMatch![0];
+      expect(handlerBody).not.toContain('event.origin');
+    });
+
+    test('extensionOrigin variable is not used in iframe message handler', () => {
+      // The extensionOrigin variable should not be computed in the in-page branch
+      const inPageBranch = containerSrc.match(
+        /} else \{\s*\/\/ In-page iframe mode[\s\S]*?return \(\) => window\.removeEventListener/
+      );
+      expect(inPageBranch, 'in-page iframe branch must exist').toBeTruthy();
+      expect(inPageBranch![0]).not.toContain('extensionOrigin');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- **Bug 1**: `getLocalStorage()` / `getSyncStorage()` can hang forever in Firefox iframes when `chrome.storage.local.get` callback never fires. Added 5s timeout + `lastError` guard so the UI falls back to defaults instead of staying stuck on "Loading..."
- **Bug 2**: `ChatContainer.tsx` origin check silently drops all content-script-relayed postMessages in Firefox (content scripts report page origin, not extension origin). Replaced `event.origin` check with `event.source === window.parent`

Fixes #35

## Test plan
- [x] 10 new source-inspection tests in `test-firefox-iframe-compat.spec.ts` — all passing
- [ ] Manual: load extension in Firefox, open Twitch/YouTube, verify login button and chat messages appear in the in-page overlay
- [ ] Manual: verify pop-out window still works in both Chrome and Firefox
- [ ] Manual: verify Chrome in-page overlay is not regressed