### PR TITLE
feat(emotes): client-side emote fallback when backend enricher misses

### DIFF
--- a/src/lib/renderMessage.tsx
+++ b/src/lib/renderMessage.tsx
@@ -18,6 +18,7 @@
 
 import React from 'react';
 import type { ChatMessage } from './types/message';
+import type { EmoteData } from './emoteAutocomplete';
 
 type PositionedEmote = {
   start: number;
@@ -28,41 +29,103 @@ type PositionedEmote = {
   key: string;
 };
 
-export function renderMessageContent(message: ChatMessage): React.ReactNode {
+/**
+ * Local emote lookup keyed by the exact (case-sensitive) emote code, used as a
+ * client-side fallback when the backend enricher returns no emotes (cold cache,
+ * TTL expiry, provider timeout). Populated from the same provider data the
+ * autocomplete uses — see `fetchAllEmotes` in `emoteAutocomplete.ts`.
+ */
+export type EmoteLookup = Map<string, EmoteData>;
+
+/**
+ * Build a code-keyed lookup from the flat emote list returned by
+ * `fetchAllEmotes`. Emote codes are case-sensitive (e.g. `Kappa` ≠ `kappa`),
+ * matching the backend's exact-token matching.
+ */
+export function buildEmoteLookup(emotes: EmoteData[]): EmoteLookup {
+  const lookup: EmoteLookup = new Map();
+  for (const emote of emotes) {
+    if (!lookup.has(emote.name)) {
+      lookup.set(emote.name, emote);
+    }
+  }
+  return lookup;
+}
+
+/**
+ * Tokenize message text on whitespace and match each token against the local
+ * emote lookup, producing the same positioned-emote shape the backend path
+ * yields. Positions use an inclusive `end` to match the backend convention.
+ */
+function buildFallbackPositions(text: string, emoteMap: EmoteLookup): PositionedEmote[] {
+  const positioned: PositionedEmote[] = [];
+  const tokenPattern = /\S+/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = tokenPattern.exec(text)) !== null) {
+    const emote = emoteMap.get(match[0]);
+    if (!emote) {
+      continue;
+    }
+
+    const start = match.index;
+    const end = start + match[0].length - 1;
+    positioned.push({
+      start,
+      end,
+      url: emote.url,
+      code: emote.name,
+      provider: emote.provider,
+      key: `fallback-${emote.name}-${start}`,
+    });
+  }
+
+  return positioned;
+}
+
+export function renderMessageContent(
+  message: ChatMessage,
+  emoteMap?: EmoteLookup,
+): React.ReactNode {
   const text = message.message?.text ?? '';
   const emotes = message.message?.emotes ?? [];
 
-  if (!text || emotes.length === 0) {
+  if (!text) {
     return text;
   }
 
-  const positioned: PositionedEmote[] = [];
+  let positioned: PositionedEmote[] = [];
 
-  emotes.forEach((emote, emoteIndex) => {
-    if (!emote.positions || emote.positions.length === 0) {
-      return;
-    }
-
-    emote.positions.forEach((pos, occurrenceIndex) => {
-      if (!Array.isArray(pos) || pos.length !== 2) {
+  if (emotes.length > 0) {
+    emotes.forEach((emote, emoteIndex) => {
+      if (!emote.positions || emote.positions.length === 0) {
         return;
       }
 
-      const [start, end] = pos;
-      if (typeof start !== 'number' || typeof end !== 'number') {
-        return;
-      }
+      emote.positions.forEach((pos, occurrenceIndex) => {
+        if (!Array.isArray(pos) || pos.length !== 2) {
+          return;
+        }
 
-      positioned.push({
-        start,
-        end,
-        url: emote.url,
-        code: emote.code,
-        provider: emote.provider,
-        key: `${emote.code}-${emoteIndex}-${occurrenceIndex}-${start}`,
+        const [start, end] = pos;
+        if (typeof start !== 'number' || typeof end !== 'number') {
+          return;
+        }
+
+        positioned.push({
+          start,
+          end,
+          url: emote.url,
+          code: emote.code,
+          provider: emote.provider,
+          key: `${emote.code}-${emoteIndex}-${occurrenceIndex}-${start}`,
+        });
       });
     });
-  });
+  } else if (emoteMap && emoteMap.size > 0) {
+    // Backend enricher returned no emotes — fall back to the locally cached map.
+    positioned = buildFallbackPositions(text, emoteMap);
+  }
 
   if (positioned.length === 0) {
     return text;

--- a/src/ui/components/ChatContainer.tsx
+++ b/src/ui/components/ChatContainer.tsx
@@ -25,7 +25,8 @@
 import React, { useState, useEffect, useLayoutEffect, useMemo, useRef, useCallback } from 'react';
 import { ChatMessage } from '../../lib/types/message';
 import { ViewerInfo } from '../../lib/types/extension';
-import { renderMessageContent } from '../../lib/renderMessage';
+import { renderMessageContent, buildEmoteLookup, type EmoteLookup } from '../../lib/renderMessage';
+import { fetchAllEmotes } from '../../lib/emoteAutocomplete';
 import { resolveTwitchBadgeIcons } from '../../lib/twitchBadges';
 import { sortMessageBadges } from '../../lib/badgeOrder';
 import { getLocalStorage, setLocalStorage, clearViewerAuth, getNameColor, getNameGradient } from '../../lib/storage';
@@ -156,6 +157,9 @@ export default function ChatContainer({ platform, streamer, displayName, twitchC
   const [tabBarMode, setTabBarMode] = useState(false); // true when platform tab bar controls view (header hidden)
   const [tabBarHideInput, setTabBarHideInput] = useState(true); // true when native input stays visible (Twitch)
   const [envNotice, setEnvNotice] = useState<Awaited<ReturnType<typeof resolveEnv>>>(null);
+  // Local emote lookup used to render emotes when the backend enricher misses
+  // (cold cache / TTL expiry). Reuses the same provider data as autocomplete.
+  const [emoteLookup, setEmoteLookup] = useState<EmoteLookup>(() => new Map());
 
   // Super Chat / Super Sticker ticker — shows recent paid events as colored pills
   interface TickerItem {
@@ -165,6 +169,29 @@ export default function ChatContainer({ platform, streamer, displayName, twitchC
     expiresAt: number; // Date.now() + duration * 1000
   }
   const [tickerItems, setTickerItems] = useState<TickerItem[]>([]);
+
+  // Pre-fetch channel emotes once on connect so the renderer has a fallback map
+  // ready before the first message arrives (7TV/BTTV/FFZ are Twitch-only).
+  useEffect(() => {
+    if (!twitchChannel) {
+      return;
+    }
+
+    let cancelled = false;
+    fetchAllEmotes(twitchChannel)
+      .then((emotes) => {
+        if (!cancelled) {
+          setEmoteLookup(buildEmoteLookup(emotes));
+        }
+      })
+      .catch((err) => {
+        console.error('[AllChat] Failed to pre-fetch fallback emotes:', err);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [twitchChannel]);
 
   useEffect(() => {
     resolveEnv().then((cfg) => {
@@ -1032,7 +1059,7 @@ export default function ChatContainer({ platform, streamer, displayName, twitchC
 
                       {/* Message text with emotes */}
                       <div className="text-sm text-text">
-                        {renderMessageContent(message)}
+                        {renderMessageContent(message, emoteLookup)}
                       </div>
                     </div>
                   ))


### PR DESCRIPTION
## Summary

Implements **issue #72** (client-side emote fallback), adapted to this repo's existing emote infrastructure.

When the backend emote enricher misses (cold Redis cache, 1h TTL expiry, provider timeout), messages arrive with an empty `emotes` array and `renderMessageContent` returned plain text until the backend cache warmed (~1 min). This adds a client-side fallback so emotes render from the first message.

## Changes

**`src/lib/renderMessage.tsx`**
- `EmoteLookup` type + `buildEmoteLookup()` (code-keyed, case-sensitive — matches backend token matching).
- `buildFallbackPositions()` tokenizes message text on whitespace, matches tokens against the local map, and emits the same positioned-emote shape as the backend path (inclusive `end`), so the existing render loop is reused.
- `renderMessageContent(message, emoteMap?)` uses the fallback **only when `message.emotes` is empty** — the backend-enriched path is unchanged and still takes precedence.

**`src/ui/components/ChatContainer.tsx`**
- Pre-fetches channel emotes once on connect via the existing `fetchAllEmotes(twitchChannel)`, builds the lookup, and passes it to the renderer. Guarded on `twitchChannel`, best-effort (catches/logs, never throws).

## Deviations from the issue's proposed file list (intentional)

- **No new `emoteLocalCache.ts` / backend `GET /emotes/channel/:channel` dependency** — this repo already fetches the same 7TV/BTTV/FFZ emotes client-side with a TTL cache (`emoteAutocomplete.ts`, used by autocomplete). A parallel cache against a redundant backend endpoint would duplicate that.
- **No `localStorage`** — in a content-script context that's the host page's storage; the existing in-memory TTL cache already covers reloads, and `chrome.storage` is the convention if persistence is ever needed.
- **Skipped part 3** (backend Redis warm) — different repo (`all-chat`), explicitly optional in the issue.

## Scope note

Like autocomplete, the fallback covers Twitch-resolved providers (7TV/BTTV/FFZ) and only when a `twitchChannel` is known — same limitation as the existing emote feature.

## Verification

- `npm run type-check` passes.
- Lint not run: repo has no ESLint v9 `eslint.config.js` (pre-existing, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)