### PR TITLE
feat(engagement): live polls/predictions & viewer points in the chat overlay

### DIFF
--- a/.planning/notes/pr89-engagement-review-plan.md
+++ b/.planning/notes/pr89-engagement-review-plan.md
@@ -1,0 +1,284 @@
+---
+name: PR #89 engagement — adversarial review & improvement plan
+description: Findings and prioritized fix plan from an adversarial review of PR #89 (live polls/predictions & viewer points in the chat overlay), verified against the all-chat backend companion (PR #524 / ADR-0031)
+type: review-plan
+date: 2026-07-07
+pr: https://github.com/caesarakalaeii/all-chat-extension/pull/89
+branch: feat/engagement-polls-predictions
+head: 04031dc
+---
+
+# PR #89 — Adversarial Review & Improvement Plan
+
+> **STATUS (2026-07-07): all 11 findings fixed + P4 test harness added + P5 ADR/docs done.**
+> Extension: items 1–8, 10, 11 implemented (uncommitted on `feat/engagement-polls-predictions`).
+> Backend: item 9 landed in all-chat commit `c64145b8`. A follow-up adversarial review of the
+> fixes surfaced 5 more defects in the new code (multi-context logout-toast race, chat-send-401
+> double toast, `requestLogin` timer leak + abandon-lockout, a weak sequencing test) — all fixed.
+> Added a vitest+jsdom unit harness (`npm run test:unit`, 26 tests). Still open (ops, not code):
+> the CORS_ORIGIN allowlist check and a manual live e2e.
+
+Review of PR #89 *"live polls/predictions & viewer points in the chat overlay"*
+(1049 additions, 11 files) against `origin/main`, cross-checked against the
+all-chat backend companion on `feature/523-engagement-polls-predictions-points`
+(PR #524 / ADR-0031).
+
+## Method
+
+Seven adversarial finder passes (contract-integration, hook-logic, panel-wiring,
+service-worker, security-privacy, test-coverage, docs-adr-version), each finding
+then challenged by two independent verifier lenses ("prove it reproduces" and
+"refute it / already handled"). 19 findings raised; 1 rejected 2/2 as unreachable,
+1 was a duplicate. **13 distinct confirmed issues** remain — all
+robustness/UX/test/docs, none architectural. Nothing is High severity.
+
+Severities below are shown as `finder → verifier-adjusted` where they differ.
+
+## Verified solid (no change needed)
+
+- **Overlay-id secrecy holds end-to-end** (ADR-0031). The security/privacy pass
+  returned zero findings: the overlay id never reaches a page/background context,
+  the extension keys everything by streamer username, and the SW is the only holder
+  of the JWT.
+- **No XSS.** `poll.question`, option/outcome `label`, `prediction.title`,
+  `points_name` are all rendered as escaped React text; the only inline style is a
+  clamped `width: ${p}%` numeric.
+- **JWT hygiene.** Token travels only in the `Authorization` header; never logged.
+- **Cross-repo contract matches** (verified directly against the backend):
+  endpoints, request/response shapes, the wager `reason` string set
+  (`not_found|not_active|bad_outcome|already_wagered|insufficient|native`),
+  `ViewerEngagement` JSON tags, gateway route registration (active in `publicAPI`;
+  me/vote/wager/heartbeat in `protectedAPI`), the `poll_update`/`prediction_update`
+  WS-frame emission on the viewer chat socket, and the OriginCheck "no Origin header
+  → allowed" path.
+
+## Considered and dismissed
+
+- **Vote-error rollback wiping a real vote** (`useEngagement.ts:169`) — rejected 2/2.
+  `chosen` is resolved from an idx drawn from the same `poll.options` the panel
+  renders and `vote` is memoized on `poll`, so the DOM handler and the closure come
+  from the same commit; `chosen` is never falsy on the only call path, so
+  `prevVotedId` is always genuinely captured. Not reachable. (Optional: gate the
+  rollback behind `if (chosen)` purely to make intent explicit — no behavior change.)
+
+---
+
+## P1 — Correctness & user-facing (fix before merge)
+
+### [ ] 1. `refresh()` has no request sequencing — a stale response reverts a fresh vote
+`medium` · `src/ui/hooks/useEngagement.ts:95`
+
+`refresh()` fires from four uncoordinated sources (initial effect, the 15s
+`ACTIVE_POLL_MS` interval, the WS-frame debounce, and post-vote/wager). The only
+guard is `aliveRef`, which flips on unmount. Confirmed race: the interval issues a
+pre-vote fetch; the viewer votes; `vote()` writes fresh tallies + fires a
+reconciling refresh; the *earlier* pre-vote response then lands last and
+`setPoll`/`setEngagement` (L106-112) overwrite the vote and clear its highlight.
+Normally self-heals on the reconciling refresh, but if that one hits the SW-asleep/5xx
+transient the code is written to tolerate, the stale state persists to the next tick.
+
+**Fix:** capture a monotonic `seqRef` before each `refresh()` await; on resolution,
+bail if `seqRef.current !== mySeq` (or use a per-refresh `AbortController`). Apply the
+same high-water check to the `vote`/`wager` `.then()` writes (L187, L216-218) so an
+in-flight earlier refresh cannot overtake the action's own writes.
+
+### [ ] 2. Intentional logout raises a misleading "Session expired" toast
+`medium → low` · `src/ui/components/ChatContainer.tsx:664`
+
+The new `storage.onChanged` recovery listener calls `handleAuthError()` on *any*
+`viewer_jwt_token` removal while the captured `viewerToken` is still truthy — and
+`handleAuthError` unconditionally toasts *"Session expired. Please log in again."*
+(L655). Deterministic repro: a signed-in viewer watching a stream clicks **Sign out
+in the popup** → the SW `clearViewerAuth()` fires `onChanged` in the still-mounted
+overlay context → a red "Session expired" warning after a *deliberate* logout. The
+state recovery itself is correct; only the copy is wrong. (`chrome.storage.onChanged`
+fires in every extension context, so an in-overlay ref flag can't suppress it.)
+
+**Fix:** make the recovery-from-`onChanged` path flip to logged-out **silently**
+(or "Signed out."). Reserve the "Session expired" copy for paths that actually detect
+expiry (the SW's `ensureValidToken` clearing on 401), or gate it behind an
+intentional-logout marker written to storage.
+
+### [ ] 3. `poll.allow_change` is never consulted — re-vote silently reverts, no feedback
+`medium → low` · `src/ui/components/EngagementPanel.tsx:160`
+
+`canVote = authed && !isNative && !isClosed` ignores both `poll.allow_change` (the
+type field exists) and whether the viewer already voted. On an `allow_change:false`
+poll the backend `RecordVote` does `ON CONFLICT DO NOTHING` but still returns
+`accepted=true` → HTTP 200, no error. So a second click optimistically moves the ✓,
+the backend no-ops, then the `/me` refetch snaps the ✓ back — a guaranteed no-op
+flicker with no explanation. The prediction path already guards the analogous case
+(`!alreadyWagered` + "locked in" hint at L330-332); polls omit it.
+
+**Fix:** in `PollBlock`, when `authed && engagement?.voted_option_id &&
+poll.allow_change === false`, set `canVote=false` (lock non-chosen options) and show
+a "You've locked in your vote" hint mirroring the prediction block. Keep options
+clickable when `allow_change` is true.
+
+---
+
+## P2 — Edge cases & polish
+
+### [ ] 4. Login / token-expiry blanks the still-public live round
+`low` · `src/ui/hooks/useEngagement.ts:119`
+
+The init effect depends on `[refresh, authed]` and unconditionally does
+`setPoll(null); setPrediction(null); setEngagement(null)` on every auth toggle — but
+`poll`/`prediction` are the *public* aggregate and don't depend on auth. The panel
+unmounts (L76 returns null) then flickers back after the refetch; if that immediate
+refetch flaps, the round stays blank until the next WS frame.
+
+**Fix:** split into two effects — one keyed on `streamer` that clears+refetches the
+round, one keyed on `authed` that only refreshes the viewer snapshot without
+pre-clearing the public round.
+
+### [ ] 5. Vote `{status:"ok"}` fallback is cast to `Poll` and blanks the poll
+`low` · `src/ui/hooks/useEngagement.ts:187` (+ `src/lib/engagementClient.ts:66`)
+
+When the backend accepts a vote but its follow-up `GetPoll` fails, it returns
+`200 {status:"ok"}`. `engagementClient.vote` does `res.data as Poll` unchecked, then
+`if (res.poll) setPoll(res.poll)` stores an object with no `state`/`options` →
+`showPoll` goes false → the poll block vanishes until the trailing `refresh()`
+reconciles. No crash, but a visible flicker right after a successful vote.
+
+**Fix (one line):** guard the hook — `if (res.poll?.id) setPoll(res.poll)` — so the
+sentinel just falls through to `refresh()`.
+
+### [ ] 6. CANCELED prediction gives the viewer no refund/cancel feedback
+`medium → low` · `src/ui/components/EngagementPanel.tsx:74`
+
+`GetActiveDisplayPrediction` serves a CANCELED prediction for the 20s grace window,
+but `showPrediction` only accepts ACTIVE/LOCKED/RESOLVED — so a viewer who staked
+points sees the panel simply vanish (balance refunded server-side, silently). It also
+keeps `roundActive` true, so the 15s interval polls an invisible panel (minor).
+
+**Fix:** add a CANCELED branch rendering a brief "Prediction canceled — wager
+refunded" reveal during the grace window, mirroring the RESOLVED state.
+
+### [ ] 7. `requestLogin` accumulates a `message` listener per click
+`medium → low` · `src/ui/components/ChatContainer.tsx:683`
+
+No re-entry guard, and the "Sign in to take part" button is never disabled. An
+impatient double-click registers two `window` listeners; when `LOGIN_SUCCESS`
+arrives, `handleLogin` runs twice → two `/auth/viewer/me` fetches and two "Logged in
+as X" toasts. Writes are idempotent and it reuses one OAuth popup, so no corruption —
+just redundant calls + a duplicate toast.
+
+**Fix:** an in-flight ref that early-returns while a login is pending (cleared on
+success/error/timeout) + disable the button while pending.
+
+### [ ] 8. `/me` 401 leaves stale "authed" UI that never reconciles
+`low` · `src/background/service-worker.ts:377`
+
+`ENGAGEMENT_ME` collapses *every* non-OK response (including a server 401) to
+`data:null`. `ensureValidToken` only clears on *local* expiry, so a token still valid
+locally but rejected server-side (key rotation, revocation, ban) yields a stale
+balance + vote highlight while every vote/wager 401s with only the generic
+"Vote failed."
+
+**Fix:** in `ENGAGEMENT_ME`, on `status===401` call `clearViewerAuth()` (triggering
+the existing `storage.onChanged` recovery → re-login prompt); keep `data:null`
+(preserve) only for 5xx/transport — mirroring the ACTIVE handler's
+transient-vs-definitive split. Key the branch off the `engagementFetch` result
+status, not the `getViewerToken()` pre-check.
+
+---
+
+## P3 — Backend dependency (all-chat repo, ship with the companion PR)
+
+### [ ] 9. `/me` excludes the grace-window states `/active` still displays
+`medium → low` · `all-chat/services/engagement-service/handler/streamer.go:126-135`
+
+`/active` uses the display queries (20s grace after CLOSED/RESOLVED); `/me` uses
+`GetActivePoll`/`GetActivePrediction` (ACTIVE/LOCKED only). During the ~20s result
+reveal the round is still on screen, but `/me` returns no
+`voted_option_id`/`wager_outcome_id`/`wager_amount` → the viewer's own ✓ / "· your
+wager 500" marker disappears at the exact moment the winner is revealed. (The Winner
+badge survives — it comes from `/active`. No data loss; the wager is still recorded.)
+Not fixable in the extension, which is never handed the round id.
+
+**Fix (backend):** have `StreamerEngagement` resolve the viewer's entry against the
+same round `/active` displays (use `GetActiveDisplayPoll/Prediction`, or look up the
+entry by the displayed round id). Not blocking on the extension.
+
+---
+
+## P4 — Test coverage (the suite is 100% static grep → false confidence)
+
+`ENG-01..07` only assert that strings exist in source files; they exercise no
+behavior. **ENG-06's currency-isolation guard is defeatable**: dropping `!isNative`
+from `canVote`/`canWager` (and the hook guard) while leaving the `isNative`
+computation keeps the `'twitch_native'` literal present, so the test stays green while
+an All-Chat vote could fire at a mirrored native round — the exact ADR-0029/0030
+invariant it claims to protect. The PR's own advertised fixes (optimistic rollback,
+`fetchActive` tri-state, transient-vs-definitive clearing) have zero executing tests,
+and these are pure/mockable — the "not reproducible in CI" caveat applies only to
+full e2e, not to unit-testing the hook with a stubbed `engagementClient`.
+
+**Decision needed:** the repo has **no unit/hook harness** (only Playwright).
+Recommended: add **jsdom + @testing-library/react** (smallest lift) and write:
+
+- [ ] Component: `PollBlock`/`PredictionBlock` with `source:'twitch_native'` → options
+  `disabled`, `onVote`/`onWager` never called; `source:'allchat'` ACTIVE → opposite.
+  *(replaces the defeatable ENG-06)*
+- [ ] `fetchActive` tri-state: `{success:false}`→`undefined`,
+  `{success:true,data:null}`→`null`, object→object.
+- [ ] `wagerRejectionCopy` table (export the fn): each reason → its copy;
+  `insufficient` interpolates `pointsName`+`balance`; unknown → fallback.
+- [ ] Optimistic-vote rollback: a failed `vote()` restores the prior `voted_option_id`.
+- [ ] `refresh()` transient-vs-definitive: `undefined` keeps the round, `null` clears it.
+
+*(Minimum without a harness: strengthen ENG-06 to grep for `!isNative` inside the
+`canVote`/`canWager` expressions — weaker, but catches the specific regression.)*
+
+Contested items (1 confirm / 1 reject) folded into the above as low-value-but-cheap:
+`wager()` reason extraction and `wagerRejectionCopy` mapping are correct today and
+fail safe via the `default` branch; worth a test only once a harness exists.
+
+---
+
+## P5 — Docs / ADR (per standing convention: architectural changes need an ADR)
+
+### [ ] 10. No extension-side ADR for the SW-proxy engagement architecture
+`medium → low` · `docs/adr/`
+
+The extension repo has an ADR mechanism (005, 006 record *smaller* decisions), but
+this PR's architectural addition — the SW message-proxy layer (`engagementFetch` + 5
+handlers), the `engagementClient` module, the message-union additions, and the
+WS-frame-as-refetch-signal pattern — is documented only as **backend** ADR-0031 in a
+different repo.
+
+**Fix:** add `docs/adr/007-streamer-keyed-engagement-sw-proxy.md` recording the
+extension-side decisions (username-keyed, overlay-id never on the wire, WS-frame
+refetch signal, token-recovery via `storage.onChanged`, optimistic rollback),
+cross-linking backend ADR-0031.
+
+### [ ] 11. Dangling "ADR-0031" references in 9 source locations
+`nit` · e.g. `src/background/service-worker.ts:349`
+
+Comments cite `ADR-0031`, which doesn't exist in this repo's `docs/adr/` (only
+005/006). They're paired with "PR #524" so intent is clear, but the citation doesn't
+resolve locally.
+
+**Fix:** qualify as "backend ADR-0031" (or point at the new local ADR-007 once
+created).
+
+---
+
+## Pre-merge verification (not code changes)
+
+- [ ] **Deployment:** confirm `CORS_ORIGIN` (caesar-deployment) allowlists the
+  extension origin (`chrome-extension://*` / `moz-extension://*`). The no-Origin
+  OriginCheck path works *if* the MV3 service worker truly sends no `Origin` on the
+  POST fetches; if Chrome attaches `Origin: chrome-extension://<id>`, the allowlist
+  entry is the fallback that keeps vote/wager/heartbeat from 403ing. One-time runtime
+  check against a production build.
+- [ ] **Manual e2e:** a real round appearing + a vote/wager landing against a running
+  engagement-service (CI can't cover it, as the PR notes).
+
+## Suggested sequencing
+
+1. **P1** (items 1-3) + items **5** and **7** — quick, high-value, low-risk; do together.
+2. **P4** — harness + tests (the larger lift; would have caught several of these).
+3. **P3** — rides with the backend PR.
+4. **P5** — satisfies the ADR convention.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ Part of [All-Chat](https://allch.at) — the free, open-source multi-platform ch
 - **Never miss a message** — Auto-reconnects with a visual countdown if your connection drops
 - **Visual send feedback** — Confirmation appears directly in the input field when your message is sent
 - **Rate limiting with feedback** — 20 messages/min, 100/hour with clear visual indicators
+- **Polls, predictions & points** — The streamer's live All-Chat polls and predictions appear right above the chat. Vote or wager your points with one click and watch the tallies update in real time. Sign in to take part; works the same across every platform the streamer broadcasts to.
+
+### Polls, Predictions & Viewer Points
+
+When a streamer runs an All-Chat poll or prediction (the cross-platform kind — separate from Twitch's own Channel Points rounds), a compact panel appears above the chat feed:
+
+- **See it live** — Question/title, per-option tallies, percentages, and the live state (open, locked, final/winner) update in real time over the same connection that delivers chat.
+- **One-click participation** — Sign in with your platform account and click an option to vote, or enter an amount and pick an outcome to wager your points. Your current vote/wager and points balance are shown inline.
+- **Twitch-native rounds are read-only** — If the streamer runs a poll/prediction through Twitch's own UI, All-Chat mirrors the live tallies for display but voting/wagering happens on Twitch (it settles in Twitch Channel Points, never All-Chat points).
+
+The extension participates by streamer username and never handles a streamer's private overlay id.
 
 ### Twitch: Tab Bar and Native Widgets
 

--- a/README.md
+++ b/README.md
@@ -107,8 +107,18 @@ npm run type-check   # TypeScript validation
 npm run lint         # ESLint
 npm run test         # Playwright E2E tests
 npm run test:agent   # Agent-tagged tests
+npm run test:unit    # Vitest unit/component tests (jsdom + Testing Library)
 npm run package      # Create distributable ZIP
 ```
+
+Two test layers:
+
+- **Playwright** (`tests/*.spec.ts`) — drives the packed extension in a real browser, plus
+  lightweight source-level regression guards for wiring that needs a running backend to
+  exercise live.
+- **Vitest** (`tests/unit/*.test.ts`) — fast jsdom unit/component tests for pure logic such as
+  the engagement hook and panel (optimistic rollback, request sequencing, native read-only
+  gating, `allow_change` locking). Kept out of the Playwright run via `testIgnore`.
 
 ### Project Structure
 
@@ -157,7 +167,9 @@ all-chat-extension/
 │   │   ├── popup.html
 │   │   └── popup.tsx
 │   └── config.ts
-├── tests/                      # Playwright E2E test suite
+├── tests/                      # Playwright E2E suite
+│   └── unit/                   # Vitest unit/component tests (jsdom)
+├── docs/adr/                   # Architecture Decision Records
 ├── assets/                     # Extension icons
 ├── manifest.json               # Manifest V3
 ├── webpack.config.js

--- a/docs/adr/007-streamer-keyed-engagement-sw-proxy.md
+++ b/docs/adr/007-streamer-keyed-engagement-sw-proxy.md
@@ -1,0 +1,101 @@
+# ADR 007: Streamer-Keyed Engagement via a Service-Worker Proxy
+
+**Status: Accepted**
+**Date: 2026-07-07**
+
+## Context
+
+All-Chat gained cross-platform polls, predictions, and viewer points (the engagement
+feature — backend issue #523 / PR #524, backend ADR-0031). The extension needs to render a
+streamer's live round inside the chat overlay and let a signed-in viewer vote or wager.
+
+Two constraints shaped the design:
+
+1. **The overlay id is a secret bearer capability.** In the backend model an engagement
+   round is addressed by the streamer's private *overlay id*; anyone holding it can read the
+   round. The extension runs in an untrusted page context (an in-page iframe on
+   twitch.tv/youtube.com/kick.com, plus a pop-out window), so the overlay id must never reach
+   a page or content-script context. Backend ADR-0031 introduced streamer-*username*-keyed
+   engagement endpoints (`/api/v1/engagement/streamers/{username}/{active,me,vote,wager,heartbeat}`)
+   precisely so viewer clients never learn the overlay id.
+2. **Only the service worker holds the viewer JWT.** The extension already centralizes the
+   viewer session (the JWT and `/auth/viewer/*` calls) in the MV3 service worker; page
+   contexts never see the raw token. Engagement's authenticated calls (`me`/`vote`/`wager`/
+   `heartbeat`) must reuse that, and gateway `OriginCheck` treats a background fetch (which
+   sends no `Origin`) as allowed, so issuing them from the SW also sidesteps CORS.
+
+The extension has its own ADR mechanism (005, 006), but the engagement decision had until now
+only been recorded as *backend* ADR-0031 in a different repository, leaving the extension-side
+architecture undocumented (review finding: PR #89, item 10).
+
+## Decision
+
+Record the extension-side engagement architecture as follows.
+
+1. **Everything is keyed by streamer username; the overlay id is never on the wire.** The
+   extension only ever calls the streamer-keyed endpoints. There is a test guard
+   (`ENG-03`) asserting no source file references an `engagement/overlays/…` route.
+
+2. **The service worker is the sole API proxy.** Five message types
+   (`ENGAGEMENT_ACTIVE`, `ENGAGEMENT_ME`, `ENGAGEMENT_VOTE`, `ENGAGEMENT_WAGER`,
+   `ENGAGEMENT_HEARTBEAT`) are handled in the SW via a shared `engagementFetch` helper that
+   resolves the gateway base URL, attaches the viewer JWT (through `ensureValidToken`, so an
+   expired session is cleared rather than sent), and parses the JSON body. Page contexts talk
+   to the SW only, through the thin `src/lib/engagementClient.ts` wrapper over
+   `chrome.runtime.sendMessage`. The overlay id and the raw JWT stay inside the SW.
+
+3. **WS frames are a refetch signal, not a state source.** The gateway fans
+   `poll_update` / `prediction_update` frames onto the same overlay chat socket the extension
+   already uses. `useEngagement` treats them purely as "something changed, refetch now" (a
+   debounced `refresh()`), mirroring the frontend's `useEngagementLive`. Authoritative state
+   always comes from the HTTP endpoints (which apply the All-Chat-over-native display
+   precedence). A live round also gets a slow (15 s) fallback poll so a dropped frame and
+   off-band point changes still reconcile; when nothing is live there is no polling.
+
+4. **Transient vs. definitive is explicit.** `fetchActive` returns `undefined` on a transient
+   failure (SW asleep / 5xx) so the last render is kept, and `null` on a definitive "no round"
+   (200 with no round, or a 404 because the overlay went private) so the panel clears.
+   `refresh()` uses a monotonic request-sequence guard, and `vote`/`wager` advance it, so a
+   stale in-flight response can never revert a fresher vote.
+
+5. **Currency isolation for mirrored Twitch-native rounds.** A round with
+   `source === 'twitch_native'` renders read-only in both the panel (the vote/wager gate) and
+   the hook (`vote`/`wager` bail before the network), so an All-Chat action can never target a
+   native round (backend ADR-0029/0030). Guarded by `ENG-06` and the jsdom component tests.
+
+6. **Session-recovery via `storage.onChanged`.** The SW clears `viewer_jwt_token` from storage
+   on expiry or a server-side rejection (a 401 on `/me`). The overlay listens for that removal
+   and flips `authed` false so the panel offers re-login. A *deliberate* logout writes a
+   short-lived `viewer_logout_intent` marker first, so the recovery path stays silent instead
+   of raising the "Session expired" toast reserved for genuine expiry.
+
+## Consequences
+
+- The overlay-id secret and the viewer JWT never leave the service worker; the extension is a
+  pure username-keyed client. This is the property backend ADR-0031 exists to enable, now
+  documented and test-guarded on the extension side.
+- Engagement state is eventually consistent with a small, bounded staleness (WS debounce +
+  15 s fallback) rather than a live subscription — acceptable for tally display and simpler
+  than a second stateful socket.
+- Adding an engagement action means adding one SW message type + one `engagementClient`
+  wrapper; the page never gains network or token access.
+- Behavior that CI cannot exercise end-to-end (a live round needs a running
+  engagement-service) is instead unit-tested with jsdom + @testing-library/react
+  (`npm run test:unit`); the Playwright suite keeps lightweight source-level regression guards
+  (`ENG-01…09`).
+
+## Alternatives Considered
+
+### Call the engagement endpoints directly from the page/iframe
+Pros: no SW round-trip. Cons: the viewer JWT would have to live in a page context, and the
+fetch would carry an `Origin` header subject to CORS. Rejected — it breaks the "only the SW
+holds the token" invariant and the no-Origin OriginCheck path.
+
+### Drive the panel purely from WS frames (no HTTP refetch)
+Pros: no polling. Cons: the frames don't carry the per-viewer snapshot (balance, this viewer's
+vote/wager) and a dropped frame would desync the tallies with no self-heal. Rejected in favor
+of frames-as-signal + authoritative HTTP, matching the frontend.
+
+### Expose the overlay id to the extension and use the overlay-keyed endpoints
+Pros: fewer backend endpoints. Cons: leaks the secret bearer capability into an untrusted page
+context. Rejected — this is the exact threat backend ADR-0031 is designed to prevent.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "All-Chat Extension",
-  "version": "1.6.4",
+  "version": "1.7.0",
   "description": "Replace native platform chat with unified All-Chat experience",
 
   "browser_specific_settings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "allchat-extension",
-  "version": "1.6.4",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "allchat-extension",
-      "version": "1.6.4",
+      "version": "1.7.0",
       "dependencies": {
         "@fontsource/dm-mono": "^5.2.7",
         "@fontsource/inter": "^5.2.8",
@@ -19,6 +19,9 @@
         "tailwind-merge": "^3.6.0"
       },
       "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/chrome": "^0.1.43",
         "@types/node": "^25.9.3",
         "@types/react": "^18.3.0",
@@ -30,12 +33,14 @@
         "css-loader": "^6.8.1",
         "eslint": "^9.39.4",
         "html-webpack-plugin": "^5.6.7",
+        "jsdom": "^29.1.1",
         "postcss": "^8.5.15",
         "postcss-loader": "^7.3.3",
         "style-loader": "^3.3.3",
         "tailwindcss": "^4.3.1",
         "ts-loader": "^9.6.2",
         "typescript": "^5.3.3",
+        "vitest": "^3.2.7",
         "webpack": "^5.107.2",
         "webpack-cli": "^5.1.4",
         "ws": "^8.21.0"
@@ -43,6 +48,13 @@
       "engines": {
         "node": ">=24"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -55,6 +67,57 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -81,6 +144,169 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -89,6 +315,448 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -284,6 +952,24 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@fontsource/dm-mono": {
       "version": "5.2.7",
       "resolved": "https://registry.npmjs.org/@fontsource/dm-mono/-/dm-mono-5.2.7.tgz",
@@ -423,6 +1109,395 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.2",
@@ -774,6 +1849,99 @@
         "tailwindcss": "4.3.2"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/chrome": {
       "version": "0.1.43",
       "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.1.43.tgz",
@@ -785,10 +1953,17 @@
         "@types/har-format": "*"
       }
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
     "node_modules/@types/filesystem": {
@@ -1116,6 +2291,121 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -1446,6 +2736,26 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -1463,6 +2773,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/boolbase": {
@@ -1524,6 +2844,16 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1565,6 +2895,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1580,6 +2927,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chrome-trace-event": {
@@ -1791,6 +3148,20 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/css-what": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
@@ -1803,6 +3174,13 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -1824,6 +3202,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1842,12 +3234,39 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1857,6 +3276,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -1995,6 +3421,48 @@
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -2217,6 +3685,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2234,6 +3712,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2280,6 +3768,24 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4.9.1"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/file-entry-cache": {
@@ -2437,6 +3943,19 @@
         "he": "bin/he"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -2582,6 +4101,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/interpret": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
@@ -2650,6 +4179,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2724,6 +4260,47 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/json-buffer": {
@@ -3111,6 +4688,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lower-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -3121,6 +4705,26 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3129,6 +4733,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -3143,6 +4754,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/mini-css-extract-plugin": {
@@ -3362,6 +4983,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/pascal-case": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
@@ -3408,6 +5055,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -3684,6 +5348,34 @@
         "renderkid": "^3.0.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3719,6 +5411,13 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/rechoir": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
@@ -3730,6 +5429,20 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/relateurl": {
@@ -3817,6 +5530,64 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -3940,6 +5711,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -3968,6 +5746,20 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -3976,6 +5768,19 @@
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -3993,6 +5798,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/style-loader": {
       "version": "3.3.4",
@@ -4036,6 +5861,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwind-merge": {
       "version": "3.6.0",
@@ -4150,6 +5982,20 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -4167,22 +6013,80 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12.0.0"
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.6.tgz",
+      "integrity": "sha512-rbP0Gyx8b3Ae9yO//CU2wbSnQNoQ66m1nJdSbSHmnwKwzkkz/u8mERYU8T2rmlmy+bJvRNn84yNCW8gYqox44Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.6"
       },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.6.tgz",
+      "integrity": "sha512-TkQNGJIhlEphpHCjKodMTSe23egUZr/g+flI2qkLgiJ/maAzSgXypSLRTNH3nCmqgayEmtcJBiLcfODSAr1xoA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
       },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4267,6 +6171,16 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
@@ -4327,6 +6241,212 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/watchpack": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
@@ -4338,6 +6458,16 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/webpack": {
@@ -4488,6 +6618,31 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4502,6 +6657,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wildcard": {
@@ -4542,6 +6714,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "allchat-extension",
-  "version": "1.6.4",
+  "version": "1.7.0",
   "private": true,
   "engines": {
     "node": ">=24"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "lint": "eslint src --ext .ts,.tsx",
     "package": "npm run build && cd dist && zip -r ../allchat-extension.zip .",
     "test": "npx playwright test --grep-invert @agent",
-    "test:agent": "npx playwright test --grep @agent"
+    "test:agent": "npx playwright test --grep @agent",
+    "test:unit": "vitest run",
+    "test:unit:watch": "vitest"
   },
   "dependencies": {
     "@fontsource/dm-mono": "^5.2.7",
@@ -27,6 +29,9 @@
     "tailwind-merge": "^3.6.0"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/chrome": "^0.1.43",
     "@types/node": "^25.9.3",
     "@types/react": "^18.3.0",
@@ -38,12 +43,14 @@
     "css-loader": "^6.8.1",
     "eslint": "^9.39.4",
     "html-webpack-plugin": "^5.6.7",
+    "jsdom": "^29.1.1",
     "postcss": "^8.5.15",
     "postcss-loader": "^7.3.3",
     "style-loader": "^3.3.3",
     "tailwindcss": "^4.3.1",
     "ts-loader": "^9.6.2",
     "typescript": "^5.3.3",
+    "vitest": "^3.2.7",
     "webpack": "^5.107.2",
     "webpack-cli": "^5.1.4",
     "ws": "^8.21.0"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,6 +3,9 @@ import path from 'path';
 
 export default defineConfig({
   testDir: './tests',
+  // tests/unit is the vitest (jsdom) suite — keep Playwright out of it, since its
+  // default testMatch would otherwise also pick up *.test.ts files there.
+  testIgnore: ['**/unit/**'],
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -346,6 +346,74 @@ chrome.runtime.onMessage.addListener((message: ExtensionMessage, sender, sendRes
           sendResponse({ success: true });
           break;
 
+        // --- Engagement (polls / predictions / points, PR #524 / ADR-0031) ---
+        // The SW is the API proxy: it resolves the base URL, attaches the viewer JWT,
+        // and calls the streamer-keyed endpoints, so the overlay id never reaches a
+        // page context and background fetches (no Origin) pass the gateway OriginCheck.
+        case 'ENGAGEMENT_ACTIVE': {
+          // Public aggregate — no token needed. A 404 (no public overlay / went private) is
+          // a DEFINITIVE "no round" → data:null so the panel clears; a 5xx/transport error
+          // is transient → success:false so the client keeps the last render.
+          const res = await engagementFetch(message.streamerUsername, '/active', { method: 'GET', auth: false });
+          if (res.ok) {
+            sendResponse({ success: true, data: res.data });
+          } else if (res.status === 404) {
+            sendResponse({ success: true, data: null });
+          } else {
+            sendResponse({ success: false, error: res.data?.error || 'ACTIVE_FAILED' });
+          }
+          break;
+        }
+
+        case 'ENGAGEMENT_ME': {
+          // Per-viewer snapshot (balance + this viewer's vote/wager). Logged-out is a
+          // normal state, not an error: return null so the panel shows aggregates only.
+          const token = await getViewerToken();
+          if (!token) {
+            sendResponse({ success: true, data: null });
+            break;
+          }
+          const res = await engagementFetch(message.streamerUsername, '/me', { method: 'GET', auth: true });
+          sendResponse(res.ok
+            ? { success: true, data: res.data }
+            : { success: true, data: null });
+          break;
+        }
+
+        case 'ENGAGEMENT_VOTE': {
+          const res = await engagementFetch(message.streamerUsername, '/vote', {
+            method: 'POST',
+            auth: true,
+            body: { poll_id: message.pollId, option_idx: message.optionIdx },
+          });
+          sendResponse(res.ok
+            ? { success: true, data: res.data }
+            : { success: false, error: res.data?.error || 'VOTE_FAILED', data: res.data });
+          break;
+        }
+
+        case 'ENGAGEMENT_WAGER': {
+          const res = await engagementFetch(message.streamerUsername, '/wager', {
+            method: 'POST',
+            auth: true,
+            body: { prediction_id: message.predictionId, outcome_idx: message.outcomeIdx, amount: message.amount },
+          });
+          // Carry the machine-readable `reason` (insufficient, already_wagered, …) through
+          // on `data` so the panel can render actionable copy.
+          sendResponse(res.ok
+            ? { success: true, data: res.data }
+            : { success: false, error: res.data?.error || 'WAGER_FAILED', data: res.data });
+          break;
+        }
+
+        case 'ENGAGEMENT_HEARTBEAT': {
+          const res = await engagementFetch(message.streamerUsername, '/heartbeat', { method: 'POST', auth: true, body: {} });
+          sendResponse(res.ok
+            ? { success: true, data: res.data }
+            : { success: false, error: res.data?.error || 'HEARTBEAT_FAILED' });
+          break;
+        }
+
         default:
           sendResponse({ success: false, error: 'Unknown message type' });
       }
@@ -792,6 +860,45 @@ async function ensureValidToken(): Promise<string | null> {
     await clearViewerAuth();
     return null;
   }
+}
+
+/**
+ * Call a streamer-keyed engagement endpoint (PR #524 / ADR-0031). Centralizes the
+ * base-URL resolution, viewer-JWT attachment, and JSON parsing for the engagement
+ * message handlers. Authenticated calls use ensureValidToken so an expired session is
+ * cleared and reported as 401 rather than silently failing. Returns the parsed body
+ * (or null) alongside ok/status so callers can surface the `reason` on a rejection.
+ */
+async function engagementFetch(
+  streamer: string,
+  path: string,
+  init: { method: 'GET' | 'POST'; auth: boolean; body?: unknown },
+): Promise<{ ok: boolean; status: number; data: any }> {
+  const apiUrl = await getApiGatewayUrl();
+  const headers: Record<string, string> = {};
+  if (init.body !== undefined) {
+    headers['Content-Type'] = 'application/json';
+  }
+  if (init.auth) {
+    const token = await ensureValidToken();
+    if (!token) {
+      return { ok: false, status: 401, data: { error: 'NOT_AUTHENTICATED' } };
+    }
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+  const url = `${apiUrl}/api/v1/engagement/streamers/${encodeURIComponent(streamer)}${path}`;
+  const response = await fetch(url, {
+    method: init.method,
+    headers,
+    ...(init.body !== undefined ? { body: JSON.stringify(init.body) } : {}),
+  });
+  let data: any = null;
+  try {
+    data = await response.json();
+  } catch {
+    /* empty or non-JSON body */
+  }
+  return { ok: response.ok, status: response.status, data };
 }
 
 /**

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -363,10 +363,15 @@ chrome.runtime.onMessage.addListener((message: ExtensionMessage, sender, sendRes
           const res = await engagementFetch(message.streamerUsername, '/active', { method: 'GET', auth: false });
           if (res.ok) {
             sendResponse({ success: true, data: res.data });
-          } else if (res.status === 404) {
+          } else if (res.status >= 400 && res.status < 500 && res.status !== 401) {
+            // Any 4xx except 401 is a DEFINITIVE answer, not a transient blip: 404 = overlay
+            // went private / no public round, 400 = bad request. Map to data:null so the panel
+            // clears. Only 5xx / transport errors stay transient (success:false → the client
+            // keeps the last render). 401 is excluded defensively — /active is unauthenticated,
+            // so a 401 signals a gateway misconfig, not "no round" (item 4).
             sendResponse({ success: true, data: null });
           } else {
-            sendResponse({ success: false, error: res.data?.error || 'ACTIVE_FAILED' });
+            sendResponse({ success: false, error: readErrorMessage(res.data) || 'ACTIVE_FAILED' });
           }
           break;
         }
@@ -401,7 +406,7 @@ chrome.runtime.onMessage.addListener((message: ExtensionMessage, sender, sendRes
           });
           sendResponse(res.ok
             ? { success: true, data: res.data }
-            : { success: false, error: res.data?.error || 'VOTE_FAILED', data: res.data });
+            : { success: false, error: readErrorMessage(res.data) || 'VOTE_FAILED', data: res.data });
           break;
         }
 
@@ -415,7 +420,7 @@ chrome.runtime.onMessage.addListener((message: ExtensionMessage, sender, sendRes
           // on `data` so the panel can render actionable copy.
           sendResponse(res.ok
             ? { success: true, data: res.data }
-            : { success: false, error: res.data?.error || 'WAGER_FAILED', data: res.data });
+            : { success: false, error: readErrorMessage(res.data) || 'WAGER_FAILED', data: res.data });
           break;
         }
 
@@ -423,7 +428,7 @@ chrome.runtime.onMessage.addListener((message: ExtensionMessage, sender, sendRes
           const res = await engagementFetch(message.streamerUsername, '/heartbeat', { method: 'POST', auth: true, body: {} });
           sendResponse(res.ok
             ? { success: true, data: res.data }
-            : { success: false, error: res.data?.error || 'HEARTBEAT_FAILED' });
+            : { success: false, error: readErrorMessage(res.data) || 'HEARTBEAT_FAILED' });
           break;
         }
 
@@ -878,6 +883,15 @@ async function ensureValidToken(): Promise<string | null> {
   }
 }
 
+/** Narrow the `error` string out of an engagement response body without an `any` cast (item 6). */
+function readErrorMessage(data: unknown): string | undefined {
+  if (data && typeof data === 'object' && 'error' in data) {
+    const { error } = data as { error?: unknown };
+    if (typeof error === 'string') return error;
+  }
+  return undefined;
+}
+
 /**
  * Call a streamer-keyed engagement endpoint (PR #524 / backend ADR-0031). Centralizes the
  * base-URL resolution, viewer-JWT attachment, and JSON parsing for the engagement
@@ -889,7 +903,7 @@ async function engagementFetch(
   streamer: string,
   path: string,
   init: { method: 'GET' | 'POST'; auth: boolean; body?: unknown },
-): Promise<{ ok: boolean; status: number; data: any }> {
+): Promise<{ ok: boolean; status: number; data: unknown }> {
   const apiUrl = await getApiGatewayUrl();
   const headers: Record<string, string> = {};
   if (init.body !== undefined) {
@@ -908,7 +922,7 @@ async function engagementFetch(
     headers,
     ...(init.body !== undefined ? { body: JSON.stringify(init.body) } : {}),
   });
-  let data: any = null;
+  let data: unknown = null;
   try {
     data = await response.json();
   } catch {

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -40,6 +40,8 @@ import {
   setLocalStorage,
   setSyncStorage,
   clearViewerAuth,
+  markIntentionalLogout,
+  clearLogoutIntent,
   setNameGradient,
   DEFAULT_SETTINGS,
 } from '../lib/storage';
@@ -302,6 +304,9 @@ chrome.runtime.onMessage.addListener((message: ExtensionMessage, sender, sendRes
         }
 
         case 'LOGOUT':
+          // Deliberate logout: mark intent before clearing so the overlay's storage.onChanged
+          // recovery flips to logged-out silently rather than toasting "Session expired" (item 2).
+          await markIntentionalLogout();
           await clearViewerAuth();
           sendResponse({ success: true });
           break;
@@ -346,7 +351,8 @@ chrome.runtime.onMessage.addListener((message: ExtensionMessage, sender, sendRes
           sendResponse({ success: true });
           break;
 
-        // --- Engagement (polls / predictions / points, PR #524 / ADR-0031) ---
+        // --- Engagement (polls / predictions / points, PR #524 / backend ADR-0031;
+        //     extension-side architecture: docs/adr/007) ---
         // The SW is the API proxy: it resolves the base URL, attaches the viewer JWT,
         // and calls the streamer-keyed endpoints, so the overlay id never reaches a
         // page context and background fetches (no Origin) pass the gateway OriginCheck.
@@ -374,6 +380,13 @@ chrome.runtime.onMessage.addListener((message: ExtensionMessage, sender, sendRes
             break;
           }
           const res = await engagementFetch(message.streamerUsername, '/me', { method: 'GET', auth: true });
+          // A server 401 on a token still valid *locally* means it was revoked/rotated (key
+          // rotation, ban) — drop it so the overlay's storage.onChanged recovery re-prompts
+          // login instead of leaving a stale authed UI whose every vote/wager 401s. Keep
+          // data:null (preserve) for 5xx/transport, mirroring the ACTIVE handler's split (item 8).
+          if (res.status === 401) {
+            await clearViewerAuth();
+          }
           sendResponse(res.ok
             ? { success: true, data: res.data }
             : { success: true, data: null });
@@ -754,6 +767,9 @@ async function saveNameColor(color: string | null): Promise<void> {
  */
 async function storeViewerToken(token: string): Promise<void> {
   await setLocalStorage({ viewer_jwt_token: token });
+  // Fresh session — clear any stale logout-intent marker so it can't later mask a genuine
+  // expiry as if it were a deliberate logout (item 2).
+  await clearLogoutIntent();
 
   try {
     const viewerInfo = await fetchViewerMe(token);
@@ -863,7 +879,7 @@ async function ensureValidToken(): Promise<string | null> {
 }
 
 /**
- * Call a streamer-keyed engagement endpoint (PR #524 / ADR-0031). Centralizes the
+ * Call a streamer-keyed engagement endpoint (PR #524 / backend ADR-0031). Centralizes the
  * base-URL resolution, viewer-JWT attachment, and JSON parsing for the engagement
  * message handlers. Authenticated calls use ensureValidToken so an expired session is
  * cleared and reported as 401 rather than silently failing. Returns the parsed body

--- a/src/lib/engagementClient.ts
+++ b/src/lib/engagementClient.ts
@@ -1,0 +1,100 @@
+/**
+ * This file is part of All-Chat Extension.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Engagement client (PR #524 / ADR-0031). Thin wrappers over the service worker,
+ * which is the API proxy — it holds the viewer JWT and calls the streamer-keyed
+ * endpoints. Works from both the in-page iframe and the pop-out window: both are
+ * extension pages with `chrome.runtime` access.
+ */
+
+import type { ExtensionMessage, ExtensionResponse } from './types/extension';
+import type { Poll, Prediction, StreamerActive, ViewerEngagement } from './types/engagement';
+
+async function send(message: ExtensionMessage): Promise<ExtensionResponse> {
+  try {
+    const res = (await chrome.runtime.sendMessage(message)) as ExtensionResponse | undefined;
+    return res ?? { success: false, error: 'NO_RESPONSE' };
+  } catch (err) {
+    // The MV3 service worker can be momentarily asleep/restarting; treat that as a
+    // transient failure the caller retries on its next tick.
+    return { success: false, error: err instanceof Error ? err.message : 'SEND_FAILED' };
+  }
+}
+
+/**
+ * Public aggregate (poll/prediction/points-name). Returns the object when a round is
+ * live, `null` when there is definitively no live/public round (200 with no round, or a
+ * 404 because the overlay went private), and `undefined` on a transient failure (service
+ * worker asleep / 5xx) so callers can keep the last render instead of wrongly clearing it.
+ */
+export async function fetchActive(streamer: string): Promise<StreamerActive | null | undefined> {
+  const res = await send({ type: 'ENGAGEMENT_ACTIVE', streamerUsername: streamer });
+  if (!res.success) return undefined;
+  return (res.data as StreamerActive | null) ?? null;
+}
+
+/** Per-viewer snapshot; null when logged out or unavailable. */
+export async function fetchMe(streamer: string): Promise<ViewerEngagement | null> {
+  const res = await send({ type: 'ENGAGEMENT_ME', streamerUsername: streamer });
+  return res.success ? ((res.data as ViewerEngagement | null) ?? null) : null;
+}
+
+export interface VoteResult {
+  poll?: Poll;
+  error?: string;
+}
+
+/** Cast/change a poll vote (option is 1-based). */
+export async function vote(streamer: string, pollId: string, optionIdx: number): Promise<VoteResult> {
+  const res = await send({ type: 'ENGAGEMENT_VOTE', streamerUsername: streamer, pollId, optionIdx });
+  if (res.success) return { poll: res.data as Poll };
+  return { error: res.error };
+}
+
+export interface WagerResult {
+  balance?: number;
+  prediction?: Prediction;
+  error?: string;
+  /** Machine-readable rejection reason (insufficient, already_wagered, not_active, …). */
+  reason?: string;
+}
+
+/** Place a points wager on a prediction outcome (outcome is 1-based). */
+export async function wager(
+  streamer: string,
+  predictionId: string,
+  outcomeIdx: number,
+  amount: number,
+): Promise<WagerResult> {
+  const res = await send({ type: 'ENGAGEMENT_WAGER', streamerUsername: streamer, predictionId, outcomeIdx, amount });
+  if (res.success) {
+    const data = res.data as { balance?: number; prediction?: Prediction } | null;
+    return { balance: data?.balance, prediction: data?.prediction };
+  }
+  const data = (res as { data?: { reason?: string } }).data;
+  return { error: res.error, reason: data?.reason };
+}
+
+/** Watch-time heartbeat; returns the new balance or null. */
+export async function heartbeat(streamer: string): Promise<number | null> {
+  const res = await send({ type: 'ENGAGEMENT_HEARTBEAT', streamerUsername: streamer });
+  if (!res.success) return null;
+  const data = res.data as { balance?: number } | null;
+  return data?.balance ?? null;
+}

--- a/src/lib/engagementClient.ts
+++ b/src/lib/engagementClient.ts
@@ -17,7 +17,7 @@
  */
 
 /**
- * Engagement client (PR #524 / ADR-0031). Thin wrappers over the service worker,
+ * Engagement client (PR #524 / backend ADR-0031). Thin wrappers over the service worker,
  * which is the API proxy — it holds the viewer JWT and calls the streamer-keyed
  * endpoints. Works from both the in-page iframe and the pop-out window: both are
  * extension pages with `chrome.runtime` access.

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -154,36 +154,32 @@ export async function clearViewerAuth(): Promise<void> {
 }
 
 /**
- * Window within which a stored logout-intent marker is honored. Short, so a marker that is
- * never cleared (e.g. the user logs out and never logs back in) cannot later mask a genuine
- * expiry.
- */
-const LOGOUT_INTENT_TTL_MS = 15_000;
-
-/**
  * Record that the imminent viewer-token removal is a *deliberate* logout (the popup's or
  * the overlay's "Sign out"), so the storage.onChanged recovery listener flips to logged-out
  * silently instead of raising a misleading "Session expired" toast (item 2). Must be awaited
- * before clearViewerAuth so the marker is in place when onChanged fires. Timestamped so a
- * marker that outlives its logout can't later mask a genuine expiry.
+ * before clearViewerAuth so the marker is in place when onChanged fires.
  */
 export async function markIntentionalLogout(): Promise<void> {
   await setLocalStorage({ viewer_logout_intent: Date.now() });
 }
 
 /**
- * Non-destructive check: was the just-observed token removal a *recent* deliberate logout?
+ * Non-destructive check: was the just-observed token removal a *deliberate* logout?
  * A PEEK, not a consume — the single viewer_jwt_token removal fires storage.onChanged in
  * EVERY extension context (the in-page iframe AND any pop-out window), each of which must
  * read the marker and stay silent. A destructive read would let whichever context lost the
- * race still raise the misleading "Session expired" toast. Staleness is bounded by the TTL,
- * and the marker is cleared on the next login (clearLogoutIntent), so it can't mask a later
- * genuine expiry.
+ * race still raise the misleading "Session expired" toast.
+ *
+ * No time window: the marker is invalidated by the *next login* (clearLogoutIntent), not by
+ * elapsed time. A genuine expiry can only follow a login (a token must exist before it can
+ * expire), and login clears the marker, so a lingering marker can never mask a later
+ * session's expiry. Dropping the former TTL also removes a multi-context race where a
+ * >TTL-delayed onChanged would wrongly toast "Session expired" after a deliberate logout
+ * (item 8).
  */
 export async function wasIntentionalLogout(): Promise<boolean> {
   const storage = await getLocalStorage();
-  const stamped = storage.viewer_logout_intent;
-  return stamped != null && Date.now() - stamped < LOGOUT_INTENT_TTL_MS;
+  return storage.viewer_logout_intent != null;
 }
 
 /** Clear the logout-intent marker. Called on login so a marker can't outlive its logout. */

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -154,6 +154,46 @@ export async function clearViewerAuth(): Promise<void> {
 }
 
 /**
+ * Window within which a stored logout-intent marker is honored. Short, so a marker that is
+ * never cleared (e.g. the user logs out and never logs back in) cannot later mask a genuine
+ * expiry.
+ */
+const LOGOUT_INTENT_TTL_MS = 15_000;
+
+/**
+ * Record that the imminent viewer-token removal is a *deliberate* logout (the popup's or
+ * the overlay's "Sign out"), so the storage.onChanged recovery listener flips to logged-out
+ * silently instead of raising a misleading "Session expired" toast (item 2). Must be awaited
+ * before clearViewerAuth so the marker is in place when onChanged fires. Timestamped so a
+ * marker that outlives its logout can't later mask a genuine expiry.
+ */
+export async function markIntentionalLogout(): Promise<void> {
+  await setLocalStorage({ viewer_logout_intent: Date.now() });
+}
+
+/**
+ * Non-destructive check: was the just-observed token removal a *recent* deliberate logout?
+ * A PEEK, not a consume — the single viewer_jwt_token removal fires storage.onChanged in
+ * EVERY extension context (the in-page iframe AND any pop-out window), each of which must
+ * read the marker and stay silent. A destructive read would let whichever context lost the
+ * race still raise the misleading "Session expired" toast. Staleness is bounded by the TTL,
+ * and the marker is cleared on the next login (clearLogoutIntent), so it can't mask a later
+ * genuine expiry.
+ */
+export async function wasIntentionalLogout(): Promise<boolean> {
+  const storage = await getLocalStorage();
+  const stamped = storage.viewer_logout_intent;
+  return stamped != null && Date.now() - stamped < LOGOUT_INTENT_TTL_MS;
+}
+
+/** Clear the logout-intent marker. Called on login so a marker can't outlive its logout. */
+export async function clearLogoutIntent(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    chrome.storage.local.remove('viewer_logout_intent', () => resolve());
+  });
+}
+
+/**
  * Get viewer name color
  */
 export async function getNameColor(): Promise<string | null> {

--- a/src/lib/types/engagement.ts
+++ b/src/lib/types/engagement.ts
@@ -1,0 +1,106 @@
+/**
+ * This file is part of All-Chat Extension.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Engagement types (polls, predictions, points — all-chat issue #523 / PR #524).
+ * These mirror the JSON the engagement-service returns; see the backend
+ * services/engagement-service/models. The extension participates by streamer
+ * username (ADR-0031) — it never learns the overlay id — so it talks to the
+ * streamer-keyed endpoints and receives live snapshots over the existing chat
+ * WebSocket as `poll_update` / `prediction_update` frames.
+ */
+
+export type EngagementSource = 'allchat' | 'twitch_native';
+export type PollState = 'ACTIVE' | 'CLOSED';
+export type PredictionState = 'CREATED' | 'ACTIVE' | 'LOCKED' | 'RESOLVED' | 'CANCELED';
+
+export interface PollOption {
+  id: string;
+  idx: number; // 1-based
+  label: string;
+  votes: number;
+}
+
+export interface Poll {
+  id: string;
+  // overlay_id is intentionally never serialized by the backend (json:"-") — the
+  // extension deals only in streamer usernames (ADR-0031).
+  source: EngagementSource;
+  external_id?: string;
+  question: string;
+  state: PollState;
+  allow_change: boolean;
+  options: PollOption[];
+  created_at: string;
+  ends_at?: string;
+  closed_at?: string;
+}
+
+export interface PredictionOutcome {
+  id: string;
+  idx: number; // 1-based
+  label: string;
+  color?: string;
+  total_points: number;
+  entrants: number;
+}
+
+export interface Prediction {
+  id: string;
+  source: EngagementSource;
+  external_id?: string;
+  title: string;
+  state: PredictionState;
+  winning_outcome_id?: string;
+  outcomes: PredictionOutcome[];
+  auto_lock_at?: string;
+  created_at: string;
+  locked_at?: string;
+  resolved_at?: string;
+}
+
+/** Private per-viewer snapshot from GET /engagement/streamers/{username}/me. */
+export interface ViewerEngagement {
+  points_name: string;
+  balance: number;
+  voted_option_id?: string;
+  wager_outcome_id?: string;
+  wager_amount?: number;
+}
+
+/** Public aggregate from GET /engagement/streamers/{username}/active. */
+export interface StreamerActive {
+  points_name: string;
+  poll: Poll | null;
+  prediction: Prediction | null;
+}
+
+/**
+ * WebSocket frame payloads. The gateway fans engagement snapshots onto the same
+ * overlay socket the extension already uses for chat; the `data` field wraps the
+ * round under `poll` / `prediction` (NOT flattened) plus an aggregate total.
+ */
+export interface PollSnapshot {
+  poll: Poll;
+  total_votes: number;
+}
+
+export interface PredictionSnapshot {
+  prediction: Prediction;
+  total_points: number;
+}

--- a/src/lib/types/engagement.ts
+++ b/src/lib/types/engagement.ts
@@ -20,7 +20,7 @@
  * Engagement types (polls, predictions, points — all-chat issue #523 / PR #524).
  * These mirror the JSON the engagement-service returns; see the backend
  * services/engagement-service/models. The extension participates by streamer
- * username (ADR-0031) — it never learns the overlay id — so it talks to the
+ * username (backend ADR-0031) — it never learns the overlay id — so it talks to the
  * streamer-keyed endpoints and receives live snapshots over the existing chat
  * WebSocket as `poll_update` / `prediction_update` frames.
  */
@@ -39,7 +39,7 @@ export interface PollOption {
 export interface Poll {
   id: string;
   // overlay_id is intentionally never serialized by the backend (json:"-") — the
-  // extension deals only in streamer usernames (ADR-0031).
+  // extension deals only in streamer usernames (backend ADR-0031).
   source: EngagementSource;
   external_id?: string;
   question: string;

--- a/src/lib/types/extension.ts
+++ b/src/lib/types/extension.ts
@@ -64,7 +64,7 @@ export type ExtensionMessage =
   | { type: 'SET_CURRENT_PLATFORM'; platform: string }
   | { type: 'EXTENSION_STATE_CHANGED'; enabled: boolean }
   | { type: 'CLOSE_POPOUT_WINDOWS' }
-  // Engagement (polls/predictions/points, PR #524 / ADR-0031). The service worker is
+  // Engagement (polls/predictions/points, PR #524 / backend ADR-0031). The service worker is
   // the API proxy: it holds the viewer JWT and calls the streamer-keyed engagement
   // endpoints, so the overlay id is never exposed to page contexts.
   | { type: 'ENGAGEMENT_ACTIVE'; streamerUsername: string }
@@ -101,6 +101,9 @@ export interface LocalStorage {
   viewer_jwt_token?: string;
   viewer_info?: ViewerInfo;
   viewer_name_color?: string;
+  // Timestamp marker written just before a *deliberate* logout so the token-removal
+  // recovery listener stays silent instead of toasting "Session expired" (item 2).
+  viewer_logout_intent?: number;
   viewer_name_gradient?: string; // JSON-serialized NameGradient, e.g. '{"type":"linear","colors":["#9146ff","#00b5ad"],"angle":90}'
   ui_collapsed?: boolean;
   // Pop-out window dimension persistence (D-07)

--- a/src/lib/types/extension.ts
+++ b/src/lib/types/extension.ts
@@ -64,6 +64,14 @@ export type ExtensionMessage =
   | { type: 'SET_CURRENT_PLATFORM'; platform: string }
   | { type: 'EXTENSION_STATE_CHANGED'; enabled: boolean }
   | { type: 'CLOSE_POPOUT_WINDOWS' }
+  // Engagement (polls/predictions/points, PR #524 / ADR-0031). The service worker is
+  // the API proxy: it holds the viewer JWT and calls the streamer-keyed engagement
+  // endpoints, so the overlay id is never exposed to page contexts.
+  | { type: 'ENGAGEMENT_ACTIVE'; streamerUsername: string }
+  | { type: 'ENGAGEMENT_ME'; streamerUsername: string }
+  | { type: 'ENGAGEMENT_VOTE'; streamerUsername: string; pollId: string; optionIdx: number }
+  | { type: 'ENGAGEMENT_WAGER'; streamerUsername: string; predictionId: string; outcomeIdx: number; amount: number }
+  | { type: 'ENGAGEMENT_HEARTBEAT'; streamerUsername: string }
   | {
       type: 'SEND_NATIVE_CHAT';
       platform: 'youtube' | 'twitch' | 'kick' | 'tiktok';

--- a/src/ui/components/ChatContainer.tsx
+++ b/src/ui/components/ChatContainer.tsx
@@ -29,7 +29,16 @@ import { renderMessageContent, buildEmoteLookup, type EmoteLookup } from '../../
 import { fetchAllEmotes } from '../../lib/emoteAutocomplete';
 import { resolveTwitchBadgeIcons } from '../../lib/twitchBadges';
 import { sortMessageBadges } from '../../lib/badgeOrder';
-import { getLocalStorage, setLocalStorage, clearViewerAuth, getNameColor, getNameGradient } from '../../lib/storage';
+import {
+  getLocalStorage,
+  setLocalStorage,
+  clearViewerAuth,
+  getNameColor,
+  getNameGradient,
+  markIntentionalLogout,
+  wasIntentionalLogout,
+  clearLogoutIntent,
+} from '../../lib/storage';
 import { API_BASE_URL } from '../../config';
 import LoginPrompt from './LoginPrompt';
 import MessageInput from './MessageInput';
@@ -163,7 +172,7 @@ export default function ChatContainer({ platform, streamer, displayName, twitchC
   // (cold cache / TTL expiry). Reuses the same provider data as autocomplete.
   const [emoteLookup, setEmoteLookup] = useState<EmoteLookup>(() => new Map());
 
-  // Engagement (polls / predictions / points, PR #524 / ADR-0031). State is pulled from
+  // Engagement (polls / predictions / points, PR #524 / backend ADR-0031). State is pulled from
   // the streamer-keyed endpoints; the poll_update / prediction_update WS frames below act
   // as a "refetch now" signal. authed = the viewer has an All-Chat session (needed to
   // vote/wager; display works without one).
@@ -173,6 +182,12 @@ export default function ChatContainer({ platform, streamer, displayName, twitchC
   // through a ref to always hit the latest refetch callback.
   const engagementFrameRef = useRef(eng.onWsFrame);
   engagementFrameRef.current = eng.onWsFrame;
+  // Panel "Sign in to take part" flow control (item 7). loginCleanupRef holds the teardown
+  // for the single in-flight attempt (message listener + timers) so a re-click/re-open
+  // replaces rather than accumulates listeners, and an unmount can't leak them; loginPending
+  // briefly disables the button as feedback without locking it if the viewer abandons OAuth.
+  const loginCleanupRef = useRef<(() => void) | null>(null);
+  const [loginPending, setLoginPending] = useState(false);
 
   // Super Chat / Super Sticker ticker — shows recent paid events as colored pills
   interface TickerItem {
@@ -610,6 +625,9 @@ export default function ChatContainer({ platform, streamer, displayName, twitchC
         viewer_jwt_token: token,
         viewer_info: info,
       });
+      // Fresh session — drop any lingering logout-intent marker so it can't later be read
+      // as intent by the recovery listener and silence a genuine expiry (item 2).
+      await clearLogoutIntent();
 
       setViewerToken(token);
       setViewerInfo(info);
@@ -639,32 +657,44 @@ export default function ChatContainer({ platform, streamer, displayName, twitchC
       console.error('[AllChat UI] Logout error:', err);
       addToast('Logout error, but session cleared locally', 'warning');
     } finally {
-      // Clear local storage regardless
+      // Mark the removal as deliberate *before* clearing so the storage.onChanged recovery
+      // listener below flips to logged-out silently instead of toasting "Session expired".
+      await markIntentionalLogout();
       await clearViewerAuth();
       setViewerToken(null);
       setViewerInfo(null);
     }
   };
 
-  // Handle auth error (token expired)
+  // Handle auth error (a 401 on chat send, wired to MessageInput's onAuthError). Clearing the
+  // token fires the storage.onChanged recovery below (handleTokenRemoved) in this same
+  // context — since no logout-intent marker is set, that path owns the state reset and the
+  // single "Session expired" toast. Don't duplicate it here (avoids a double toast). We keep
+  // viewerToken truthy until the recovery runs so the listener's guard still fires.
   const handleAuthError = async () => {
     console.log('[AllChat UI] Auth error, clearing session');
     await clearViewerAuth();
-    setViewerToken(null);
-    setViewerInfo(null);
-    addToast('Session expired. Please log in again.', 'warning');
   };
 
-  // Recover when the viewer token is wiped mid-session. The service worker's
-  // ensureValidToken() (and the chat send path) clear viewer_jwt_token from storage on
-  // expiry, but the UI's viewerToken state wouldn't otherwise notice — leaving the
-  // engagement panel showing a stale balance with controls that silently fail. Mirror any
-  // token removal into React state so `authed` flips false and the panel offers re-login.
-  // storage.onChanged fires in every extension context (in-page iframe and pop-out).
+  // Recover when the viewer token is wiped mid-session. The service worker clears
+  // viewer_jwt_token from storage on expiry / server-side rejection, but the UI's
+  // viewerToken state wouldn't otherwise notice — leaving the engagement panel showing a
+  // stale balance with controls that silently fail. Mirror any token removal into React
+  // state so `authed` flips false and the panel offers re-login. A deliberate logout carries
+  // the intent marker (consumed here) and stays silent; only a genuine expiry/revocation
+  // toasts. storage.onChanged fires in every extension context, so an in-overlay flag can't
+  // suppress it — the marker in storage is the cross-context signal (item 2).
+  const handleTokenRemoved = async () => {
+    const intentional = await wasIntentionalLogout();
+    await clearViewerAuth();
+    setViewerToken(null);
+    setViewerInfo(null);
+    if (!intentional) addToast('Session expired. Please log in again.', 'warning');
+  };
   useEffect(() => {
     const onChanged = (changes: Record<string, chrome.storage.StorageChange>, area: string) => {
       if (area === 'local' && changes.viewer_jwt_token && changes.viewer_jwt_token.newValue == null && viewerToken) {
-        void handleAuthError();
+        void handleTokenRemoved();
       }
     };
     chrome.storage.onChanged.addListener(onChanged);
@@ -682,22 +712,45 @@ export default function ChatContainer({ platform, streamer, displayName, twitchC
   // script. Pop-out windows have no content-script parent, so the panel hides this.
   const requestLogin = () => {
     if (isPopOut) return;
-    window.parent.postMessage({ type: 'REQUEST_LOGIN', platform, streamer }, '*');
+    // Tear down any prior in-flight attempt first, so only ONE message listener/timer set is
+    // ever active — a second click (or the content script re-opening the popup) replaces
+    // rather than accumulates. This is what prevents the double /me + double toast (item 7),
+    // independent of the button-disable below.
+    loginCleanupRef.current?.();
+    setLoginPending(true);
+
     const handler = (event: MessageEvent) => {
       if (event.source !== window.parent) return;
       const d = event.data as { type?: string; token?: string; error?: string };
       if (d?.type === 'LOGIN_SUCCESS' && d.token) {
-        window.removeEventListener('message', handler);
+        cleanup();
         void handleLogin(d.token);
       } else if (d?.type === 'LOGIN_ERROR') {
-        window.removeEventListener('message', handler);
+        cleanup();
         addToast(d.error || 'Login failed', 'error');
       }
     };
+    // Re-enable the button shortly (prevents an accidental double-click, but doesn't lock
+    // sign-in if the viewer abandons the OAuth window); the listener stays armed for the
+    // real result until the hard timeout.
+    const enableTimer = setTimeout(() => setLoginPending(false), 3_000);
+    // Hard stop after 3 minutes (mirrors LoginPrompt) — tears everything down.
+    const hardTimer = setTimeout(() => cleanup(), 180_000);
+    const cleanup = () => {
+      window.removeEventListener('message', handler);
+      clearTimeout(enableTimer);
+      clearTimeout(hardTimer);
+      setLoginPending(false);
+      loginCleanupRef.current = null;
+    };
+    loginCleanupRef.current = cleanup;
+
     window.addEventListener('message', handler);
-    // Stop listening after 3 minutes (mirrors LoginPrompt's timeout).
-    setTimeout(() => window.removeEventListener('message', handler), 180_000);
+    window.parent.postMessage({ type: 'REQUEST_LOGIN', platform, streamer }, '*');
   };
+
+  // Tear down an in-flight login attempt (listener + timers) if the overlay unmounts.
+  useEffect(() => () => loginCleanupRef.current?.(), []);
 
   // Toggle collapse state and persist it (in-page only)
   const toggleCollapse = async () => {
@@ -938,6 +991,7 @@ export default function ChatContainer({ platform, streamer, displayName, twitchC
                 notice={eng.notice}
                 authed={authed}
                 canLogin={!isPopOut}
+                loginPending={loginPending}
                 onVote={eng.vote}
                 onWager={eng.wager}
                 onRequestLogin={requestLogin}

--- a/src/ui/components/ChatContainer.tsx
+++ b/src/ui/components/ChatContainer.tsx
@@ -33,6 +33,8 @@ import { getLocalStorage, setLocalStorage, clearViewerAuth, getNameColor, getNam
 import { API_BASE_URL } from '../../config';
 import LoginPrompt from './LoginPrompt';
 import MessageInput from './MessageInput';
+import EngagementPanel from './EngagementPanel';
+import { useEngagement } from '../hooks/useEngagement';
 import ToastContainer, { Toast } from './Toast';
 import { InfinityLogo } from './InfinityLogo';
 import { UserAvatar } from './UserAvatar';
@@ -160,6 +162,17 @@ export default function ChatContainer({ platform, streamer, displayName, twitchC
   // Local emote lookup used to render emotes when the backend enricher misses
   // (cold cache / TTL expiry). Reuses the same provider data as autocomplete.
   const [emoteLookup, setEmoteLookup] = useState<EmoteLookup>(() => new Map());
+
+  // Engagement (polls / predictions / points, PR #524 / ADR-0031). State is pulled from
+  // the streamer-keyed endpoints; the poll_update / prediction_update WS frames below act
+  // as a "refetch now" signal. authed = the viewer has an All-Chat session (needed to
+  // vote/wager; display works without one).
+  const authed = Boolean(viewerToken);
+  const eng = useEngagement(streamer, authed);
+  // The WS message handler is captured by an effect (see below), so route frame signals
+  // through a ref to always hit the latest refetch callback.
+  const engagementFrameRef = useRef(eng.onWsFrame);
+  engagementFrameRef.current = eng.onWsFrame;
 
   // Super Chat / Super Sticker ticker — shows recent paid events as colored pills
   interface TickerItem {
@@ -391,6 +404,10 @@ export default function ChatContainer({ platform, streamer, displayName, twitchC
             return prev;
           });
         });
+      } else if (wsMessage.type === 'poll_update' || wsMessage.type === 'prediction_update') {
+        // Engagement snapshot changed (PR #524). The frame is a signal; the hook refetches
+        // the authoritative state (which applies All-Chat-over-native display precedence).
+        engagementFrameRef.current?.();
       } else if (wsMessage.type === 'ping') {
         // Ignore pings
       }
@@ -638,9 +655,48 @@ export default function ChatContainer({ platform, streamer, displayName, twitchC
     addToast('Session expired. Please log in again.', 'warning');
   };
 
+  // Recover when the viewer token is wiped mid-session. The service worker's
+  // ensureValidToken() (and the chat send path) clear viewer_jwt_token from storage on
+  // expiry, but the UI's viewerToken state wouldn't otherwise notice — leaving the
+  // engagement panel showing a stale balance with controls that silently fail. Mirror any
+  // token removal into React state so `authed` flips false and the panel offers re-login.
+  // storage.onChanged fires in every extension context (in-page iframe and pop-out).
+  useEffect(() => {
+    const onChanged = (changes: Record<string, chrome.storage.StorageChange>, area: string) => {
+      if (area === 'local' && changes.viewer_jwt_token && changes.viewer_jwt_token.newValue == null && viewerToken) {
+        void handleAuthError();
+      }
+    };
+    chrome.storage.onChanged.addListener(onChanged);
+    return () => chrome.storage.onChanged.removeListener(onChanged);
+  }, [viewerToken]); // eslint-disable-line react-hooks/exhaustive-deps
+
   // Handle message sent successfully
   const handleMessageSent = () => {
     // Inline feedback handled by MessageInput — no toast needed
+  };
+
+  // Trigger the viewer OAuth flow from the engagement panel (a logged-out viewer on
+  // Twitch/YouTube/Kick sees the native input, not the LoginPrompt, so the panel offers
+  // its own sign-in). Reuses the LoginPrompt REQUEST_LOGIN relay through the content
+  // script. Pop-out windows have no content-script parent, so the panel hides this.
+  const requestLogin = () => {
+    if (isPopOut) return;
+    window.parent.postMessage({ type: 'REQUEST_LOGIN', platform, streamer }, '*');
+    const handler = (event: MessageEvent) => {
+      if (event.source !== window.parent) return;
+      const d = event.data as { type?: string; token?: string; error?: string };
+      if (d?.type === 'LOGIN_SUCCESS' && d.token) {
+        window.removeEventListener('message', handler);
+        void handleLogin(d.token);
+      } else if (d?.type === 'LOGIN_ERROR') {
+        window.removeEventListener('message', handler);
+        addToast(d.error || 'Login failed', 'error');
+      }
+    };
+    window.addEventListener('message', handler);
+    // Stop listening after 3 minutes (mirrors LoginPrompt's timeout).
+    setTimeout(() => window.removeEventListener('message', handler), 180_000);
   };
 
   // Toggle collapse state and persist it (in-page only)
@@ -870,6 +926,23 @@ export default function ChatContainer({ platform, streamer, displayName, twitchC
                   })}
                 </div>
               )}
+
+              {/* Live poll / prediction panel (PR #524). Renders nothing when no round is
+                  active; sits above the message list like the Super Chat ticker. */}
+              <EngagementPanel
+                poll={eng.poll}
+                prediction={eng.prediction}
+                engagement={eng.engagement}
+                pointsName={eng.pointsName}
+                busy={eng.busy}
+                notice={eng.notice}
+                authed={authed}
+                canLogin={!isPopOut}
+                onVote={eng.vote}
+                onWager={eng.wager}
+                onRequestLogin={requestLogin}
+                onDismissNotice={eng.clearNotice}
+              />
 
               {/* Messages */}
               <div id="messages-container" ref={messagesContainerRef} onScroll={handleScroll} className="flex-1 overflow-y-auto p-3 space-y-2">

--- a/src/ui/components/EngagementPanel.tsx
+++ b/src/ui/components/EngagementPanel.tsx
@@ -72,6 +72,14 @@ export default function EngagementPanel({
     if (wagerLocked) setWagerAmount('');
   }, [wagerLocked]);
 
+  // Also clear when the round itself rolls over (new prediction id), so a half-typed amount
+  // left over from a previous prediction can't be submitted against the next one (item 2).
+  // Keyed on the id (not the object) so a tally refresh of the *same* round doesn't wipe an
+  // amount the viewer is mid-way through typing.
+  useEffect(() => {
+    setWagerAmount('');
+  }, [prediction?.id]);
+
   const showPoll = poll && (poll.state === 'ACTIVE' || poll.state === 'CLOSED');
   // CANCELED is included so the ~20s cancel grace window (served by the backend's display
   // query) renders a "refunded" reveal instead of the panel silently vanishing (item 6).
@@ -258,7 +266,10 @@ function PredictionBlock({
   const isResolved = prediction.state === 'RESOLVED';
   const isCanceled = prediction.state === 'CANCELED';
   const alreadyWagered = Boolean(engagement?.wager_outcome_id);
-  const canWager = authed && !isNative && isOpen && !alreadyWagered;
+  // Require a loaded viewer snapshot too: without `engagement`, `balance` falls back to 0 and
+  // a wager would be rejected client-side with "you have 0" even for a viewer who *has* points
+  // but whose /me is momentarily unavailable. Hide the input until the snapshot loads (item 7).
+  const canWager = authed && !isNative && isOpen && !alreadyWagered && Boolean(engagement);
 
   return (
     <section className="space-y-1.5">

--- a/src/ui/components/EngagementPanel.tsx
+++ b/src/ui/components/EngagementPanel.tsx
@@ -18,7 +18,7 @@
 
 /**
  * EngagementPanel renders the streamer's live All-Chat poll / prediction inside the
- * chat overlay (PR #524 / ADR-0031). Presentational only — all state and actions come
+ * chat overlay (PR #524 / backend ADR-0031). Presentational only — all state and actions come
  * from useEngagement. Mirrors the no-install participate page and the OBS widgets:
  * live bars with tallies, one-click vote, a wager input, and read-only rendering of a
  * mirrored Twitch-native round. Renders nothing when no round is live.
@@ -37,6 +37,8 @@ interface EngagementPanelProps {
   authed: boolean;
   /** REQUEST_LOGIN needs the content-script relay, absent in the pop-out window. */
   canLogin: boolean;
+  /** True while an OAuth login is in flight — disables the sign-in button (no double-launch). */
+  loginPending?: boolean;
   onVote: (optionIdx: number) => void;
   onWager: (outcomeIdx: number, amount: number) => void;
   onRequestLogin: () => void;
@@ -54,6 +56,7 @@ export default function EngagementPanel({
   notice,
   authed,
   canLogin,
+  loginPending = false,
   onVote,
   onWager,
   onRequestLogin,
@@ -70,8 +73,14 @@ export default function EngagementPanel({
   }, [wagerLocked]);
 
   const showPoll = poll && (poll.state === 'ACTIVE' || poll.state === 'CLOSED');
+  // CANCELED is included so the ~20s cancel grace window (served by the backend's display
+  // query) renders a "refunded" reveal instead of the panel silently vanishing (item 6).
   const showPrediction =
-    prediction && (prediction.state === 'ACTIVE' || prediction.state === 'LOCKED' || prediction.state === 'RESOLVED');
+    prediction &&
+    (prediction.state === 'ACTIVE' ||
+      prediction.state === 'LOCKED' ||
+      prediction.state === 'RESOLVED' ||
+      prediction.state === 'CANCELED');
 
   if (!showPoll && !showPrediction) return null;
 
@@ -129,9 +138,10 @@ export default function EngagementPanel({
       {!authed && canLogin && (
         <button
           onClick={onRequestLogin}
-          className="w-full rounded bg-purple-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-purple-700"
+          disabled={loginPending}
+          className="w-full rounded bg-purple-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-purple-700 disabled:cursor-default disabled:opacity-60 disabled:hover:bg-purple-600"
         >
-          Sign in to take part
+          {loginPending ? 'Opening sign-in…' : 'Sign in to take part'}
         </button>
       )}
       {!authed && !canLogin && (
@@ -157,7 +167,13 @@ function PollBlock({
   const total = poll.options.reduce((s, o) => s + o.votes, 0);
   const isNative = poll.source === 'twitch_native';
   const isClosed = poll.state === 'CLOSED';
-  const canVote = authed && !isNative && !isClosed;
+  // Once a viewer has voted on an allow_change:false poll, the backend no-ops a second
+  // vote (ON CONFLICT DO NOTHING) yet still returns 200 — so an unguarded re-click would
+  // optimistically move the ✓ and then snap back on the /me refetch. Lock the options and
+  // show a hint, mirroring the prediction block (item 3).
+  const alreadyVoted = Boolean(engagement?.voted_option_id);
+  const voteLocked = alreadyVoted && poll.allow_change === false;
+  const canVote = authed && !isNative && !isClosed && !voteLocked;
   const maxVotes = poll.options.reduce((m, o) => Math.max(m, o.votes), 0);
 
   return (
@@ -207,6 +223,9 @@ function PollBlock({
           </button>
         );
       })}
+      {authed && voteLocked && !isClosed && (
+        <p className="text-xs text-[var(--color-text-dim)]">You&apos;ve locked in your vote for this round.</p>
+      )}
     </section>
   );
 }
@@ -237,6 +256,7 @@ function PredictionBlock({
   const isOpen = prediction.state === 'ACTIVE';
   const isLocked = prediction.state === 'LOCKED';
   const isResolved = prediction.state === 'RESOLVED';
+  const isCanceled = prediction.state === 'CANCELED';
   const alreadyWagered = Boolean(engagement?.wager_outcome_id);
   const canWager = authed && !isNative && isOpen && !alreadyWagered;
 
@@ -255,9 +275,19 @@ function PredictionBlock({
             Resolved
           </span>
         )}
+        {isCanceled && (
+          <span className="shrink-0 rounded bg-surface-2 px-1.5 py-0.5 text-[10px] font-bold uppercase text-[var(--color-text-sub)]">
+            Canceled
+          </span>
+        )}
       </h3>
       {isNative && (
         <p className="text-xs text-[var(--color-text-dim)]">Runs on Twitch channel points.</p>
+      )}
+      {isCanceled && (
+        <p className="text-xs text-[var(--color-text-dim)]">
+          Prediction canceled{alreadyWagered ? ' — your wager was refunded' : ''}.
+        </p>
       )}
 
       {canWager && (

--- a/src/ui/components/EngagementPanel.tsx
+++ b/src/ui/components/EngagementPanel.tsx
@@ -1,0 +1,335 @@
+/**
+ * This file is part of All-Chat Extension.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * EngagementPanel renders the streamer's live All-Chat poll / prediction inside the
+ * chat overlay (PR #524 / ADR-0031). Presentational only — all state and actions come
+ * from useEngagement. Mirrors the no-install participate page and the OBS widgets:
+ * live bars with tallies, one-click vote, a wager input, and read-only rendering of a
+ * mirrored Twitch-native round. Renders nothing when no round is live.
+ */
+
+import React, { useEffect, useState } from 'react';
+import type { Poll, Prediction, ViewerEngagement } from '../../lib/types/engagement';
+
+interface EngagementPanelProps {
+  poll: Poll | null;
+  prediction: Prediction | null;
+  engagement: ViewerEngagement | null;
+  pointsName: string;
+  busy: boolean;
+  notice: string | null;
+  authed: boolean;
+  /** REQUEST_LOGIN needs the content-script relay, absent in the pop-out window. */
+  canLogin: boolean;
+  onVote: (optionIdx: number) => void;
+  onWager: (outcomeIdx: number, amount: number) => void;
+  onRequestLogin: () => void;
+  onDismissNotice: () => void;
+}
+
+const pct = (part: number, total: number) => (total > 0 ? Math.round((part / total) * 100) : 0);
+
+export default function EngagementPanel({
+  poll,
+  prediction,
+  engagement,
+  pointsName,
+  busy,
+  notice,
+  authed,
+  canLogin,
+  onVote,
+  onWager,
+  onRequestLogin,
+  onDismissNotice,
+}: EngagementPanelProps) {
+  const [wagerAmount, setWagerAmount] = useState('');
+
+  // Clear the input only once the wager is actually locked in (wager_outcome_id becomes
+  // set) — never on a rejection, so a viewer whose wager bounced (insufficient / already /
+  // closed) can adjust and retry without retyping the amount.
+  const wagerLocked = Boolean(engagement?.wager_outcome_id);
+  useEffect(() => {
+    if (wagerLocked) setWagerAmount('');
+  }, [wagerLocked]);
+
+  const showPoll = poll && (poll.state === 'ACTIVE' || poll.state === 'CLOSED');
+  const showPrediction =
+    prediction && (prediction.state === 'ACTIVE' || prediction.state === 'LOCKED' || prediction.state === 'RESOLVED');
+
+  if (!showPoll && !showPrediction) return null;
+
+  const balance = engagement?.balance ?? 0;
+
+  return (
+    <div className="border-b border-border bg-surface px-3 py-2 space-y-3 text-sm">
+      {/* Header: title + balance */}
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-xs font-semibold uppercase tracking-wide text-[var(--color-text-dim)]">
+          Live now
+        </span>
+        {authed && engagement && (
+          <span
+            className="rounded-full bg-surface-2 px-2 py-0.5 text-xs font-semibold text-text"
+            title={`Your ${pointsName}`}
+          >
+            🔥 {balance.toLocaleString()} {pointsName}
+          </span>
+        )}
+      </div>
+
+      {notice && (
+        <div
+          role="alert"
+          className="flex items-start justify-between gap-2 rounded bg-red-500/15 px-2 py-1.5 text-xs text-red-300"
+        >
+          <span>{notice}</span>
+          <button
+            onClick={onDismissNotice}
+            aria-label="Dismiss"
+            className="shrink-0 text-red-300 hover:text-red-200"
+          >
+            ✕
+          </button>
+        </div>
+      )}
+
+      {showPoll && <PollBlock poll={poll!} engagement={engagement} authed={authed} busy={busy} onVote={onVote} />}
+
+      {showPrediction && (
+        <PredictionBlock
+          prediction={prediction!}
+          engagement={engagement}
+          pointsName={pointsName}
+          balance={balance}
+          authed={authed}
+          busy={busy}
+          wagerAmount={wagerAmount}
+          setWagerAmount={setWagerAmount}
+          onWager={onWager}
+        />
+      )}
+
+      {!authed && canLogin && (
+        <button
+          onClick={onRequestLogin}
+          className="w-full rounded bg-purple-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-purple-700"
+        >
+          Sign in to take part
+        </button>
+      )}
+      {!authed && !canLogin && (
+        <p className="text-xs text-[var(--color-text-dim)]">Sign in from the chat window to take part.</p>
+      )}
+    </div>
+  );
+}
+
+function PollBlock({
+  poll,
+  engagement,
+  authed,
+  busy,
+  onVote,
+}: {
+  poll: Poll;
+  engagement: ViewerEngagement | null;
+  authed: boolean;
+  busy: boolean;
+  onVote: (optionIdx: number) => void;
+}) {
+  const total = poll.options.reduce((s, o) => s + o.votes, 0);
+  const isNative = poll.source === 'twitch_native';
+  const isClosed = poll.state === 'CLOSED';
+  const canVote = authed && !isNative && !isClosed;
+  const maxVotes = poll.options.reduce((m, o) => Math.max(m, o.votes), 0);
+
+  return (
+    <section className="space-y-1.5">
+      <h3 className="flex items-center gap-1.5 font-semibold text-text">
+        <span aria-hidden>📊</span>
+        <span className="min-w-0 flex-1 truncate">{poll.question}</span>
+        {isClosed && (
+          <span className="shrink-0 rounded bg-surface-2 px-1.5 py-0.5 text-[10px] font-bold uppercase text-[var(--color-text-sub)]">
+            Final
+          </span>
+        )}
+      </h3>
+      {isNative && (
+        <p className="text-xs text-[var(--color-text-dim)]">Runs on Twitch — vote in Twitch chat.</p>
+      )}
+      {poll.options.map((o) => {
+        const p = pct(o.votes, total);
+        const mine = engagement?.voted_option_id === o.id;
+        const isWinner = isClosed && maxVotes > 0 && o.votes === maxVotes;
+        return (
+          <button
+            key={o.id}
+            type="button"
+            onClick={() => canVote && onVote(o.idx)}
+            disabled={!canVote || busy}
+            aria-pressed={mine}
+            className={`relative flex w-full items-center justify-between overflow-hidden rounded border px-2 py-1.5 text-left ${
+              mine ? 'border-purple-500' : 'border-border'
+            } ${canVote && !busy ? 'hover:border-purple-400 cursor-pointer' : 'cursor-default'} ${
+              !canVote && !isClosed ? 'opacity-80' : ''
+            }`}
+          >
+            <span className="absolute inset-y-0 left-0 bg-purple-500/20" style={{ width: `${p}%` }} />
+            <span className="relative min-w-0 flex-1 truncate font-medium text-text">
+              {o.idx}. {o.label}
+              {mine && <span className="ml-1" aria-hidden>✓</span>}
+              {isWinner && (
+                <span className="ml-1 rounded bg-yellow-400 px-1 py-0.5 text-[9px] font-bold uppercase text-black">
+                  Winner
+                </span>
+              )}
+            </span>
+            <span className="relative ml-2 shrink-0 tabular-nums text-xs text-[var(--color-text-sub)]">
+              {p}% ({o.votes.toLocaleString()})
+            </span>
+          </button>
+        );
+      })}
+    </section>
+  );
+}
+
+function PredictionBlock({
+  prediction,
+  engagement,
+  pointsName,
+  balance,
+  authed,
+  busy,
+  wagerAmount,
+  setWagerAmount,
+  onWager,
+}: {
+  prediction: Prediction;
+  engagement: ViewerEngagement | null;
+  pointsName: string;
+  balance: number;
+  authed: boolean;
+  busy: boolean;
+  wagerAmount: string;
+  setWagerAmount: (v: string) => void;
+  onWager: (outcomeIdx: number, amount: number) => void;
+}) {
+  const total = prediction.outcomes.reduce((s, o) => s + o.total_points, 0);
+  const isNative = prediction.source === 'twitch_native';
+  const isOpen = prediction.state === 'ACTIVE';
+  const isLocked = prediction.state === 'LOCKED';
+  const isResolved = prediction.state === 'RESOLVED';
+  const alreadyWagered = Boolean(engagement?.wager_outcome_id);
+  const canWager = authed && !isNative && isOpen && !alreadyWagered;
+
+  return (
+    <section className="space-y-1.5">
+      <h3 className="flex items-center gap-1.5 font-semibold text-text">
+        <span aria-hidden>🔮</span>
+        <span className="min-w-0 flex-1 truncate">{prediction.title}</span>
+        {isLocked && (
+          <span className="shrink-0 text-[10px] font-bold uppercase text-[var(--color-text-sub)]" aria-hidden>
+            🔒 Locked
+          </span>
+        )}
+        {isResolved && (
+          <span className="shrink-0 rounded bg-surface-2 px-1.5 py-0.5 text-[10px] font-bold uppercase text-[var(--color-text-sub)]">
+            Resolved
+          </span>
+        )}
+      </h3>
+      {isNative && (
+        <p className="text-xs text-[var(--color-text-dim)]">Runs on Twitch channel points.</p>
+      )}
+
+      {canWager && (
+        <div className="flex items-center gap-2">
+          <label htmlFor="allchat-wager" className="sr-only">
+            Amount to wager in {pointsName}
+          </label>
+          <input
+            id="allchat-wager"
+            type="number"
+            min={1}
+            max={balance}
+            inputMode="numeric"
+            value={wagerAmount}
+            onChange={(e) => setWagerAmount(e.target.value)}
+            placeholder={`Wager (${pointsName})`}
+            className="w-full rounded border border-border bg-bg px-2 py-1 text-xs text-text placeholder-[var(--color-text-dim)] focus:outline-hidden focus:border-[var(--color-text-dim)]"
+          />
+          <button
+            type="button"
+            onClick={() => setWagerAmount(String(balance))}
+            className="shrink-0 rounded px-1.5 py-1 text-xs font-medium text-[var(--color-text-sub)] underline hover:text-text"
+          >
+            Max
+          </button>
+        </div>
+      )}
+
+      {prediction.outcomes.map((o) => {
+        const p = pct(o.total_points, total);
+        const mine = engagement?.wager_outcome_id === o.id;
+        const isWinner = isResolved && prediction.winning_outcome_id === o.id;
+        return (
+          <button
+            key={o.id}
+            type="button"
+            onClick={() => {
+              if (!canWager) return;
+              const amt = Number.parseInt(wagerAmount, 10);
+              onWager(o.idx, amt);
+            }}
+            disabled={!canWager || busy}
+            aria-pressed={mine}
+            className={`relative flex w-full items-center justify-between overflow-hidden rounded border px-2 py-1.5 text-left ${
+              mine ? 'border-sky-500' : 'border-border'
+            } ${canWager && !busy ? 'hover:border-sky-400 cursor-pointer' : 'cursor-default'} ${
+              isWinner ? 'border-yellow-400' : ''
+            }`}
+          >
+            <span className="absolute inset-y-0 left-0 bg-sky-500/20" style={{ width: `${p}%` }} />
+            <span className="relative min-w-0 flex-1 truncate font-medium text-text">
+              {o.idx}. {o.label}
+              {mine && (
+                <span className="ml-1 text-[var(--color-text-sub)]">
+                  · your wager {(engagement?.wager_amount ?? 0).toLocaleString()}
+                </span>
+              )}
+              {isWinner && (
+                <span className="ml-1 rounded bg-yellow-400 px-1 py-0.5 text-[9px] font-bold uppercase text-black">
+                  Winner
+                </span>
+              )}
+            </span>
+            <span className="relative ml-2 shrink-0 tabular-nums text-xs text-[var(--color-text-sub)]">
+              {o.total_points.toLocaleString()} · {p}%
+            </span>
+          </button>
+        );
+      })}
+      {authed && alreadyWagered && isOpen && (
+        <p className="text-xs text-[var(--color-text-dim)]">You&apos;ve locked in your wager for this round.</p>
+      )}
+    </section>
+  );
+}

--- a/src/ui/hooks/useEngagement.ts
+++ b/src/ui/hooks/useEngagement.ts
@@ -1,0 +1,227 @@
+/**
+ * This file is part of All-Chat Extension.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { Poll, Prediction, ViewerEngagement } from '../../lib/types/engagement';
+import * as engagementApi from '../../lib/engagementClient';
+
+/**
+ * useEngagement drives the extension's poll/prediction panel (PR #524 / ADR-0031).
+ *
+ * The authoritative state is pulled from the streamer-keyed HTTP endpoints (which
+ * apply the All-Chat-over-native display precedence). The overlay chat WebSocket
+ * delivers `poll_update` / `prediction_update` frames — we treat those purely as a
+ * "something changed, refetch now" signal (via `onWsFrame`), matching the frontend's
+ * `useEngagementLive`. A live round also gets a slow fallback poll so a missed frame
+ * and points earned off-band (subs/bits) still reconcile; when nothing is live there
+ * is no polling — the next round's creation frame wakes us.
+ */
+
+const REFRESH_DEBOUNCE_MS = 400;
+const ACTIVE_POLL_MS = 15_000;
+const HEARTBEAT_MS = 60_000;
+
+// wagerRejectionCopy maps the server's machine reason for a rejected wager to human
+// copy, so a failure is actionable rather than the opaque "wager not accepted".
+// Reasons come from the engagement-service repository WagerResult.Reason.
+function wagerRejectionCopy(reason: string | undefined, pointsName: string, balance: number): string {
+  switch (reason) {
+    case 'not_found':
+      return 'This prediction is no longer available.';
+    case 'not_active':
+      return 'Betting is closed for this round.';
+    case 'bad_outcome':
+      return 'That outcome is not valid.';
+    case 'already_wagered':
+      return 'You already placed a wager this round.';
+    case 'insufficient':
+      return `Not enough ${pointsName}. You have ${balance.toLocaleString()}.`;
+    case 'native':
+      return 'This prediction runs on Twitch channel points.';
+    default:
+      return 'Wager not accepted.';
+  }
+}
+
+export interface EngagementState {
+  poll: Poll | null;
+  prediction: Prediction | null;
+  engagement: ViewerEngagement | null;
+  pointsName: string;
+  busy: boolean;
+  notice: string | null;
+  vote: (optionIdx: number) => void;
+  wager: (outcomeIdx: number, amount: number) => void;
+  clearNotice: () => void;
+  /** Called by ChatContainer when a poll_update/prediction_update WS frame arrives. */
+  onWsFrame: () => void;
+}
+
+export function useEngagement(streamer: string, authed: boolean): EngagementState {
+  const [poll, setPoll] = useState<Poll | null>(null);
+  const [prediction, setPrediction] = useState<Prediction | null>(null);
+  const [engagement, setEngagement] = useState<ViewerEngagement | null>(null);
+  const [pointsName, setPointsName] = useState('Points');
+  const [busy, setBusy] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const aliveRef = useRef(true);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const authedRef = useRef(authed);
+  authedRef.current = authed;
+
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => {
+      aliveRef.current = false;
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    if (!streamer) return;
+    const [active, me] = await Promise.all([
+      engagementApi.fetchActive(streamer),
+      authedRef.current ? engagementApi.fetchMe(streamer) : Promise.resolve<ViewerEngagement | null>(null),
+    ]);
+    if (!aliveRef.current) return;
+    // fetchActive returns undefined on a transient failure (SW asleep / 5xx) — keep the
+    // last round rendered; null or an object is a definitive answer (incl. a 404 when the
+    // overlay went private, or a 200 with no live round) — clear/replace accordingly.
+    if (active !== undefined) {
+      setPoll(active?.poll ?? null);
+      setPrediction(active?.prediction ?? null);
+      if (active?.points_name) setPointsName(active.points_name);
+    }
+    if (me) {
+      setEngagement(me);
+      if (me.points_name) setPointsName(me.points_name);
+    } else if (!authedRef.current) {
+      setEngagement(null);
+    }
+  }, [streamer]);
+
+  // Initial load + reset when the watched stream changes.
+  useEffect(() => {
+    setPoll(null);
+    setPrediction(null);
+    setEngagement(null);
+    void refresh();
+  }, [refresh, authed]);
+
+  // Fallback reconcile while a round is live (self-heals a dropped frame; refreshes the
+  // balance earned off-band). Keyed on presence, not the round objects, so a tally change
+  // doesn't churn the timer — it arms when a round appears and tears down when it's gone.
+  const roundActive = Boolean(poll || prediction);
+  useEffect(() => {
+    if (!roundActive) return;
+    const t = setInterval(() => void refresh(), ACTIVE_POLL_MS);
+    return () => clearInterval(t);
+  }, [refresh, roundActive]);
+
+  // Watch-time heartbeat while logged in — awards the streamer's configured points and
+  // keeps the shown balance current.
+  useEffect(() => {
+    if (!authed || !streamer) return;
+    const t = setInterval(() => {
+      void engagementApi.heartbeat(streamer).then((balance) => {
+        if (balance != null && aliveRef.current) {
+          setEngagement((prev) => (prev ? { ...prev, balance } : prev));
+        }
+      });
+    }, HEARTBEAT_MS);
+    return () => clearInterval(t);
+  }, [authed, streamer]);
+
+  const onWsFrame = useCallback(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => void refresh(), REFRESH_DEBOUNCE_MS);
+  }, [refresh]);
+
+  useEffect(() => () => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+  }, []);
+
+  const clearNotice = useCallback(() => setNotice(null), []);
+
+  const vote = useCallback(
+    (optionIdx: number) => {
+      if (!poll || busy || poll.source === 'twitch_native') return;
+      setBusy(true);
+      setNotice(null);
+      // Optimistic: highlight the chosen option immediately (the id is resolved from idx).
+      // Capture the prior vote inside the updater (engagement isn't a dep) so a failure can
+      // roll the highlight back even if the reconciling refetch also fails.
+      const chosen = poll.options.find((o) => o.idx === optionIdx);
+      let prevVotedId: string | undefined;
+      if (chosen) {
+        setEngagement((prev) => {
+          if (!prev) return prev;
+          prevVotedId = prev.voted_option_id;
+          return { ...prev, voted_option_id: chosen.id };
+        });
+      }
+      void engagementApi.vote(streamer, poll.id, optionIdx).then((res) => {
+        if (!aliveRef.current) return;
+        setBusy(false);
+        if (res.error) {
+          setNotice('Vote failed. Try again.');
+          setEngagement((prev) => (prev ? { ...prev, voted_option_id: prevVotedId } : prev));
+          void refresh();
+          return;
+        }
+        if (res.poll) setPoll(res.poll);
+        void refresh();
+      });
+    },
+    [poll, busy, streamer, refresh]
+  );
+
+  const wager = useCallback(
+    (outcomeIdx: number, amount: number) => {
+      if (!prediction || busy || prediction.source === 'twitch_native') return;
+      if (!Number.isFinite(amount) || amount <= 0) {
+        setNotice('Enter a positive amount to wager.');
+        return;
+      }
+      const balance = engagement?.balance ?? 0;
+      if (amount > balance) {
+        setNotice(`Not enough ${pointsName}. You have ${balance.toLocaleString()}.`);
+        return;
+      }
+      setBusy(true);
+      setNotice(null);
+      void engagementApi.wager(streamer, prediction.id, outcomeIdx, amount).then((res) => {
+        if (!aliveRef.current) return;
+        setBusy(false);
+        if (res.error) {
+          setNotice(wagerRejectionCopy(res.reason, pointsName, balance));
+          void refresh();
+          return;
+        }
+        if (res.prediction) setPrediction(res.prediction);
+        if (res.balance != null) {
+          setEngagement((prev) => (prev ? { ...prev, balance: res.balance! } : prev));
+        }
+        void refresh();
+      });
+    },
+    [prediction, busy, streamer, engagement, pointsName, refresh]
+  );
+
+  return { poll, prediction, engagement, pointsName, busy, notice, vote, wager, clearNotice, onWsFrame };
+}

--- a/src/ui/hooks/useEngagement.ts
+++ b/src/ui/hooks/useEngagement.ts
@@ -86,6 +86,11 @@ export function useEngagement(streamer: string, authed: boolean): EngagementStat
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const authedRef = useRef(authed);
   authedRef.current = authed;
+  // Latest engagement snapshot, read inside async callbacks (wager) so a rejection message
+  // reflects the *current* balance rather than the value captured when the memoized callback
+  // was created (item 5). Same escape-hatch pattern as authedRef.
+  const engagementRef = useRef(engagement);
+  engagementRef.current = engagement;
   // Monotonic request-sequence guard. refresh() runs from four uncoordinated sources
   // (init, the live-round interval, the WS-frame debounce, and post-vote/wager), and a
   // vote/wager races its own reconciling refresh. Each refresh captures the seq before its
@@ -166,8 +171,18 @@ export function useEngagement(streamer: string, authed: boolean): EngagementStat
   useEffect(() => {
     if (!authed || !streamer) return;
     const t = setInterval(() => {
+      // Capture the request-sequence high-water WITHOUT advancing it, then apply the balance
+      // the heartbeat POST already returns. Applying it in place keeps the update cheap and
+      // preserves the "no polling when nothing is live" design above — routing this through
+      // refresh() would instead fetch /active + /me every 60s for every idle logged-in viewer.
+      const mySeq = seqRef.current;
       void engagementApi.heartbeat(streamer).then((balance) => {
-        if (balance != null && aliveRef.current) {
+        // Apply only if no newer writer (a vote/wager, or a refresh) has advanced seqRef since
+        // we fired — a heartbeat that resolves *after* a vote/wager would otherwise clobber the
+        // post-action balance with its stale pre-action value (item 1). We deliberately do NOT
+        // advance seqRef ourselves, so this never causes a concurrent refresh to bail. A null
+        // balance means the heartbeat itself failed (SW asleep / 5xx) — keep the last render.
+        if (balance != null && aliveRef.current && seqRef.current === mySeq) {
           setEngagement((prev) => (prev ? { ...prev, balance } : prev));
         }
       });
@@ -245,7 +260,11 @@ export function useEngagement(streamer: string, authed: boolean): EngagementStat
         if (!aliveRef.current) return;
         setBusy(false);
         if (res.error) {
-          setNotice(wagerRejectionCopy(res.reason, pointsName, balance));
+          // Read the freshest balance — `engagement` (and thus the `balance` captured above)
+          // is stale in this memoized callback, so an `insufficient` message would otherwise
+          // show the submit-time figure rather than the current one (item 5).
+          const currentBalance = engagementRef.current?.balance ?? balance;
+          setNotice(wagerRejectionCopy(res.reason, pointsName, currentBalance));
           void refresh();
           return;
         }

--- a/src/ui/hooks/useEngagement.ts
+++ b/src/ui/hooks/useEngagement.ts
@@ -21,7 +21,8 @@ import type { Poll, Prediction, ViewerEngagement } from '../../lib/types/engagem
 import * as engagementApi from '../../lib/engagementClient';
 
 /**
- * useEngagement drives the extension's poll/prediction panel (PR #524 / ADR-0031).
+ * useEngagement drives the extension's poll/prediction panel (PR #524 / backend ADR-0031;
+ * extension-side architecture: docs/adr/007-streamer-keyed-engagement-sw-proxy.md).
  *
  * The authoritative state is pulled from the streamer-keyed HTTP endpoints (which
  * apply the All-Chat-over-native display precedence). The overlay chat WebSocket
@@ -39,7 +40,8 @@ const HEARTBEAT_MS = 60_000;
 // wagerRejectionCopy maps the server's machine reason for a rejected wager to human
 // copy, so a failure is actionable rather than the opaque "wager not accepted".
 // Reasons come from the engagement-service repository WagerResult.Reason.
-function wagerRejectionCopy(reason: string | undefined, pointsName: string, balance: number): string {
+// Exported for unit testing (the reason→copy table).
+export function wagerRejectionCopy(reason: string | undefined, pointsName: string, balance: number): string {
   switch (reason) {
     case 'not_found':
       return 'This prediction is no longer available.';
@@ -84,6 +86,12 @@ export function useEngagement(streamer: string, authed: boolean): EngagementStat
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const authedRef = useRef(authed);
   authedRef.current = authed;
+  // Monotonic request-sequence guard. refresh() runs from four uncoordinated sources
+  // (init, the live-round interval, the WS-frame debounce, and post-vote/wager), and a
+  // vote/wager races its own reconciling refresh. Each refresh captures the seq before its
+  // await and bails on resolution if a newer refresh or action has bumped it; each action
+  // bumps it up-front so a stale in-flight refresh can never revert a fresh vote (item 1).
+  const seqRef = useRef(0);
 
   useEffect(() => {
     aliveRef.current = true;
@@ -94,11 +102,14 @@ export function useEngagement(streamer: string, authed: boolean): EngagementStat
 
   const refresh = useCallback(async () => {
     if (!streamer) return;
+    const mySeq = ++seqRef.current;
     const [active, me] = await Promise.all([
       engagementApi.fetchActive(streamer),
       authedRef.current ? engagementApi.fetchMe(streamer) : Promise.resolve<ViewerEngagement | null>(null),
     ]);
-    if (!aliveRef.current) return;
+    // Bail if unmounted, or if a newer refresh / a vote·wager has superseded this one —
+    // a stale response must never overwrite fresher state (item 1).
+    if (!aliveRef.current || seqRef.current !== mySeq) return;
     // fetchActive returns undefined on a transient failure (SW asleep / 5xx) — keep the
     // last round rendered; null or an object is a definitive answer (incl. a 404 when the
     // overlay went private, or a 200 with no live round) — clear/replace accordingly.
@@ -115,13 +126,30 @@ export function useEngagement(streamer: string, authed: boolean): EngagementStat
     }
   }, [streamer]);
 
-  // Initial load + reset when the watched stream changes.
+  // Initial load + reset when the watched stream changes. `refresh`'s identity changes
+  // only when `streamer` does, so this clears the stale round and refetches on a switch.
   useEffect(() => {
     setPoll(null);
     setPrediction(null);
     setEngagement(null);
     void refresh();
-  }, [refresh, authed]);
+  }, [refresh]);
+
+  // On an auth change (login / logout / expiry) refresh the viewer snapshot *in place*.
+  // The poll/prediction are the PUBLIC aggregate and don't depend on auth, so we must not
+  // blank them on a toggle (which flickered the still-live round, item 4). Keyed on `authed`
+  // alone (refresh is read through a ref so a streamer switch doesn't double-fetch here);
+  // the mount run is skipped since the effect above already did the initial fetch.
+  const refreshRef = useRef(refresh);
+  refreshRef.current = refresh;
+  const didAuthMountRef = useRef(false);
+  useEffect(() => {
+    if (!didAuthMountRef.current) {
+      didAuthMountRef.current = true;
+      return;
+    }
+    void refreshRef.current();
+  }, [authed]);
 
   // Fallback reconcile while a round is live (self-heals a dropped frame; refreshes the
   // balance earned off-band). Keyed on presence, not the round objects, so a tally change
@@ -163,6 +191,9 @@ export function useEngagement(streamer: string, authed: boolean): EngagementStat
       if (!poll || busy || poll.source === 'twitch_native') return;
       setBusy(true);
       setNotice(null);
+      // Advance the request-sequence high-water so any refresh already in flight (e.g. a
+      // pre-vote interval fetch) bails on resolution instead of reverting this vote (item 1).
+      seqRef.current++;
       // Optimistic: highlight the chosen option immediately (the id is resolved from idx).
       // Capture the prior vote inside the updater (engagement isn't a dep) so a failure can
       // roll the highlight back even if the reconciling refetch also fails.
@@ -184,7 +215,10 @@ export function useEngagement(streamer: string, authed: boolean): EngagementStat
           void refresh();
           return;
         }
-        if (res.poll) setPoll(res.poll);
+        // Only a real poll carries an id; the backend returns a bodyless 200 {status:"ok"}
+        // when it accepted the vote but its GetPoll follow-up failed — ignore that sentinel
+        // so it doesn't blank the live poll until the trailing refresh reconciles (item 5).
+        if (res.poll?.id) setPoll(res.poll);
         void refresh();
       });
     },
@@ -205,6 +239,8 @@ export function useEngagement(streamer: string, authed: boolean): EngagementStat
       }
       setBusy(true);
       setNotice(null);
+      // Supersede any in-flight refresh so it can't overwrite this wager's result (item 1).
+      seqRef.current++;
       void engagementApi.wager(streamer, prediction.id, outcomeIdx, amount).then((res) => {
         if (!aliveRef.current) return;
         setBusy(false);

--- a/tests/test-engagement-integration.spec.ts
+++ b/tests/test-engagement-integration.spec.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path from 'path';
 
 /**
- * Static source-checks for the engagement integration (all-chat PR #524 / ADR-0031):
+ * Static source-checks for the engagement integration (all-chat PR #524 / backend ADR-0031):
  * polls, predictions, and viewer points inside the extension chat overlay.
  *
  * A live end-to-end (an actual poll appearing + a vote landing) requires a running
@@ -11,11 +11,17 @@ import path from 'path';
  * reproducible in CI — so these guard the wiring and, critically, the invariant that the
  * extension participates by streamer *username* and never handles an overlay id
  * (the viewer-withheld bearer capability). Same file-reading style as test-design-system.
+ *
+ * Behavior (the hook/panel logic — optimistic rollback, request sequencing, the native
+ * read-only gate, allow_change locking, the wager-rejection copy) is exercised for real by
+ * the jsdom unit suite in tests/unit/*.test.ts (`npm run test:unit`). The checks here are
+ * regression guardrails for the pieces that unit tests can't reach cheaply: the service
+ * worker's message switch and the ChatContainer auth wiring.
  */
 
 const read = (p: string) => fs.readFileSync(path.resolve(__dirname, '..', p), 'utf8');
 
-test.describe('Engagement integration (PR #524 / ADR-0031)', () => {
+test.describe('Engagement integration (PR #524 / backend ADR-0031)', () => {
   test('ENG-01: engagement types exist (Poll, Prediction, StreamerActive, snapshots)', () => {
     const t = read('src/lib/types/engagement.ts');
     for (const sym of ['interface Poll', 'interface Prediction', 'interface StreamerActive', 'interface ViewerEngagement', 'PollSnapshot', 'PredictionSnapshot']) {
@@ -34,7 +40,7 @@ test.describe('Engagement integration (PR #524 / ADR-0031)', () => {
   });
 
   test('ENG-03: overlay-id secrecy — the extension never builds an overlay-keyed engagement URL', () => {
-    // ADR-0031: viewers must not learn the overlay id. Any /engagement/overlays/... call
+    // backend ADR-0031: viewers must not learn the overlay id. Any /engagement/overlays/... call
     // from the extension would mean an overlay id crossed into a page/background context.
     for (const f of [
       'src/background/service-worker.ts',
@@ -65,10 +71,38 @@ test.describe('Engagement integration (PR #524 / ADR-0031)', () => {
   test('ENG-06: mirrored Twitch-native rounds render read-only (no vote/wager)', () => {
     // Currency isolation (ADR-0029/0030): the panel and hook must gate participation on
     // source !== twitch_native so an All-Chat vote/wager can never target a native round.
+    // Behavior is proven in tests/unit/engagementPanel.test.tsx; this guards against the
+    // specific regression of dropping `!isNative` from the gate while leaving the literal —
+    // which defeated the old contains-only check — by asserting it inside canVote/canWager.
     const panel = read('src/ui/components/EngagementPanel.tsx');
     const hook = read('src/ui/hooks/useEngagement.ts');
-    expect(panel).toContain("'twitch_native'");
-    expect(hook).toContain("=== 'twitch_native'");
+    expect(panel).toMatch(/const canVote = [^;]*!isNative/);
+    expect(panel).toMatch(/const canWager = [^;]*!isNative/);
+    // Hook belt-and-braces: vote()/wager() bail on a native round before hitting the network.
+    expect(hook).toContain("poll.source === 'twitch_native'");
+    expect(hook).toContain("prediction.source === 'twitch_native'");
+  });
+
+  test('ENG-08: a server 401 on /me drops the token so the UI re-prompts (item 8)', () => {
+    // A locally-valid but server-rejected token (revoked/rotated/ban) must not leave a stale
+    // authed UI whose every vote/wager 401s. The ENGAGEMENT_ME handler clears auth on 401.
+    const sw = read('src/background/service-worker.ts');
+    const meCase = sw.slice(sw.indexOf("case 'ENGAGEMENT_ME'"), sw.indexOf("case 'ENGAGEMENT_VOTE'"));
+    expect(meCase).toMatch(/res\.status === 401/);
+    expect(meCase).toContain('clearViewerAuth()');
+  });
+
+  test('ENG-09: deliberate logout is marked so recovery stays silent (item 2)', () => {
+    // A deliberate "Sign out" must not raise the "Session expired" toast reserved for a real
+    // expiry. Both logout paths mark intent; the ChatContainer recovery listener consumes it.
+    const sw = read('src/background/service-worker.ts');
+    const cc = read('src/ui/components/ChatContainer.tsx');
+    // SW popup-logout path marks intent before clearing.
+    expect(sw).toContain('markIntentionalLogout()');
+    // Overlay recovery peeks the marker (non-destructive, so multiple contexts stay silent)
+    // instead of always toasting.
+    expect(cc).toContain('wasIntentionalLogout()');
+    expect(cc).toContain('markIntentionalLogout()');
   });
 
   test('ENG-07: version bumped past 1.6.x and manifest/package agree', () => {

--- a/tests/test-engagement-integration.spec.ts
+++ b/tests/test-engagement-integration.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Static source-checks for the engagement integration (all-chat PR #524 / ADR-0031):
+ * polls, predictions, and viewer points inside the extension chat overlay.
+ *
+ * A live end-to-end (an actual poll appearing + a vote landing) requires a running
+ * engagement-service and a streamer with a public overlay running a round, which is not
+ * reproducible in CI — so these guard the wiring and, critically, the invariant that the
+ * extension participates by streamer *username* and never handles an overlay id
+ * (the viewer-withheld bearer capability). Same file-reading style as test-design-system.
+ */
+
+const read = (p: string) => fs.readFileSync(path.resolve(__dirname, '..', p), 'utf8');
+
+test.describe('Engagement integration (PR #524 / ADR-0031)', () => {
+  test('ENG-01: engagement types exist (Poll, Prediction, StreamerActive, snapshots)', () => {
+    const t = read('src/lib/types/engagement.ts');
+    for (const sym of ['interface Poll', 'interface Prediction', 'interface StreamerActive', 'interface ViewerEngagement', 'PollSnapshot', 'PredictionSnapshot']) {
+      expect(t, `missing ${sym}`).toContain(sym);
+    }
+  });
+
+  test('ENG-02: service worker proxies the streamer-keyed endpoints for every engagement action', () => {
+    const sw = read('src/background/service-worker.ts');
+    for (const msg of ['ENGAGEMENT_ACTIVE', 'ENGAGEMENT_ME', 'ENGAGEMENT_VOTE', 'ENGAGEMENT_WAGER', 'ENGAGEMENT_HEARTBEAT']) {
+      expect(sw, `SW does not handle ${msg}`).toContain(`case '${msg}'`);
+    }
+    // The SW is the API proxy; it must call the streamer-keyed base and attach the JWT.
+    expect(sw).toContain('/api/v1/engagement/streamers/');
+    expect(sw).toContain('ensureValidToken()');
+  });
+
+  test('ENG-03: overlay-id secrecy — the extension never builds an overlay-keyed engagement URL', () => {
+    // ADR-0031: viewers must not learn the overlay id. Any /engagement/overlays/... call
+    // from the extension would mean an overlay id crossed into a page/background context.
+    for (const f of [
+      'src/background/service-worker.ts',
+      'src/lib/engagementClient.ts',
+      'src/ui/hooks/useEngagement.ts',
+      'src/ui/components/EngagementPanel.tsx',
+    ]) {
+      expect(read(f), `${f} references an overlay-keyed engagement route`).not.toContain('engagement/overlays/');
+    }
+  });
+
+  test('ENG-04: the client talks to the service worker via chrome.runtime.sendMessage', () => {
+    const c = read('src/lib/engagementClient.ts');
+    expect(c).toContain('chrome.runtime.sendMessage');
+    for (const fn of ['fetchActive', 'fetchMe', 'export async function vote', 'export async function wager', 'export async function heartbeat']) {
+      expect(c, `client missing ${fn}`).toContain(fn);
+    }
+  });
+
+  test('ENG-05: ChatContainer handles poll_update / prediction_update frames and mounts the panel', () => {
+    const cc = read('src/ui/components/ChatContainer.tsx');
+    expect(cc).toContain("wsMessage.type === 'poll_update'");
+    expect(cc).toContain("wsMessage.type === 'prediction_update'");
+    expect(cc).toContain('<EngagementPanel');
+    expect(cc).toContain('useEngagement(');
+  });
+
+  test('ENG-06: mirrored Twitch-native rounds render read-only (no vote/wager)', () => {
+    // Currency isolation (ADR-0029/0030): the panel and hook must gate participation on
+    // source !== twitch_native so an All-Chat vote/wager can never target a native round.
+    const panel = read('src/ui/components/EngagementPanel.tsx');
+    const hook = read('src/ui/hooks/useEngagement.ts');
+    expect(panel).toContain("'twitch_native'");
+    expect(hook).toContain("=== 'twitch_native'");
+  });
+
+  test('ENG-07: version bumped past 1.6.x and manifest/package agree', () => {
+    const pkg = JSON.parse(read('package.json')) as { version: string };
+    const manifest = JSON.parse(read('manifest.json')) as { version: string };
+    expect(pkg.version).toBe(manifest.version);
+    expect(pkg.version, 'expected a feature bump above 1.6.x').not.toMatch(/^1\.6\./);
+  });
+});

--- a/tests/unit/engagementClient.test.ts
+++ b/tests/unit/engagementClient.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as client from '../../src/lib/engagementClient';
+import type { StreamerActive } from '../../src/lib/types/engagement';
+
+// engagementClient is a thin wrapper over chrome.runtime.sendMessage (the SW proxy).
+// Stub chrome so we can assert how each SW response is mapped for the hook.
+const sendMessage = vi.fn();
+beforeEach(() => {
+  sendMessage.mockReset();
+  (globalThis as unknown as { chrome: unknown }).chrome = {
+    runtime: { sendMessage },
+  };
+});
+
+const activePayload: StreamerActive = { points_name: 'Points', poll: null, prediction: null };
+
+describe('fetchActive tri-state (transient vs definitive)', () => {
+  it('maps a transient SW failure to undefined so the caller keeps the last render', async () => {
+    sendMessage.mockResolvedValue({ success: false, error: 'ACTIVE_FAILED' });
+    await expect(client.fetchActive('streamer')).resolves.toBeUndefined();
+  });
+
+  it('maps a definitive "no round" (success + null data) to null so the caller clears', async () => {
+    sendMessage.mockResolvedValue({ success: true, data: null });
+    await expect(client.fetchActive('streamer')).resolves.toBeNull();
+  });
+
+  it('returns the round object when one is live', async () => {
+    sendMessage.mockResolvedValue({ success: true, data: activePayload });
+    await expect(client.fetchActive('streamer')).resolves.toEqual(activePayload);
+  });
+
+  it('maps a thrown/asleep service worker to undefined (transient)', async () => {
+    sendMessage.mockRejectedValue(new Error('Could not establish connection'));
+    await expect(client.fetchActive('streamer')).resolves.toBeUndefined();
+  });
+});
+
+describe('vote() result mapping', () => {
+  it('surfaces an error without a poll when the SW reports failure', async () => {
+    sendMessage.mockResolvedValue({ success: false, error: 'VOTE_FAILED' });
+    await expect(client.vote('s', 'poll-1', 1)).resolves.toEqual({ error: 'VOTE_FAILED' });
+  });
+});
+
+describe('wager() result mapping', () => {
+  it('carries the machine-readable rejection reason through on failure', async () => {
+    sendMessage.mockResolvedValue({ success: false, error: 'WAGER_FAILED', data: { reason: 'insufficient' } });
+    await expect(client.wager('s', 'pred-1', 1, 500)).resolves.toEqual({
+      error: 'WAGER_FAILED',
+      reason: 'insufficient',
+    });
+  });
+});

--- a/tests/unit/engagementPanel.test.tsx
+++ b/tests/unit/engagementPanel.test.tsx
@@ -136,6 +136,40 @@ describe('EngagementPanel — poll.allow_change (item 3)', () => {
   });
 });
 
+describe('EngagementPanel — All-Chat wager (item 3)', () => {
+  it('lets an authed viewer type an amount and wager it on an outcome', () => {
+    const { onWager } = renderPanel({
+      prediction: makePrediction(),
+      engagement: { points_name: 'Points', balance: 1000 },
+    });
+    const input = screen.getByLabelText(/amount to wager/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '250' } });
+    const yes = screen.getByRole('button', { name: /Yes/ });
+    fireEvent.click(yes);
+    expect(onWager).toHaveBeenCalledWith(1, 250);
+  });
+
+  it('does not offer wagering to a logged-out viewer', () => {
+    const { onWager } = renderPanel({ prediction: makePrediction(), authed: false, engagement: null });
+    expect(screen.queryByLabelText(/amount to wager/i)).not.toBeInTheDocument();
+    const yes = screen.getByRole('button', { name: /Yes/ });
+    expect(yes).toBeDisabled();
+    fireEvent.click(yes);
+    expect(onWager).not.toHaveBeenCalled();
+  });
+
+  it('hides the wager input until the viewer snapshot has loaded (item 7)', () => {
+    // authed but engagement still null (transient /me failure): showing the input would let a
+    // wager compute balance=0 and bounce with "you have 0" even for a viewer who has points.
+    const { onWager } = renderPanel({ prediction: makePrediction(), authed: true, engagement: null });
+    expect(screen.queryByLabelText(/amount to wager/i)).not.toBeInTheDocument();
+    const yes = screen.getByRole('button', { name: /Yes/ });
+    expect(yes).toBeDisabled();
+    fireEvent.click(yes);
+    expect(onWager).not.toHaveBeenCalled();
+  });
+});
+
 describe('EngagementPanel — CANCELED prediction (item 6)', () => {
   it('reveals a refund message during the cancel grace window instead of vanishing', () => {
     renderPanel({

--- a/tests/unit/engagementPanel.test.tsx
+++ b/tests/unit/engagementPanel.test.tsx
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import EngagementPanel from '../../src/ui/components/EngagementPanel';
+import type {
+  Poll,
+  Prediction,
+  ViewerEngagement,
+  EngagementSource,
+  PollState,
+  PredictionState,
+} from '../../src/lib/types/engagement';
+
+function makePoll(over: Partial<Poll> = {}): Poll {
+  return {
+    id: 'poll-1',
+    source: 'allchat' as EngagementSource,
+    question: 'Best language?',
+    state: 'ACTIVE' as PollState,
+    allow_change: true,
+    options: [
+      { id: 'opt-1', idx: 1, label: 'Rust', votes: 3 },
+      { id: 'opt-2', idx: 2, label: 'Go', votes: 1 },
+    ],
+    created_at: '2026-07-07T00:00:00Z',
+    ...over,
+  };
+}
+
+function makePrediction(over: Partial<Prediction> = {}): Prediction {
+  return {
+    id: 'pred-1',
+    source: 'allchat' as EngagementSource,
+    title: 'Will they win?',
+    state: 'ACTIVE' as PredictionState,
+    outcomes: [
+      { id: 'out-1', idx: 1, label: 'Yes', total_points: 100, entrants: 2 },
+      { id: 'out-2', idx: 2, label: 'No', total_points: 50, entrants: 1 },
+    ],
+    created_at: '2026-07-07T00:00:00Z',
+    ...over,
+  };
+}
+
+const noop = () => {};
+
+function renderPanel(props: Partial<React.ComponentProps<typeof EngagementPanel>> = {}) {
+  const onVote = vi.fn();
+  const onWager = vi.fn();
+  render(
+    <EngagementPanel
+      poll={null}
+      prediction={null}
+      engagement={null}
+      pointsName="Points"
+      busy={false}
+      notice={null}
+      authed={true}
+      canLogin={true}
+      onVote={onVote}
+      onWager={onWager}
+      onRequestLogin={noop}
+      onDismissNotice={noop}
+      loginPending={false}
+      {...props}
+    />,
+  );
+  return { onVote, onWager };
+}
+
+describe('EngagementPanel — currency isolation (native rounds are read-only)', () => {
+  it('disables poll options and never fires onVote for a mirrored Twitch-native poll', () => {
+    const { onVote } = renderPanel({ poll: makePoll({ source: 'twitch_native' }) });
+    const opt = screen.getByRole('button', { name: /Rust/ });
+    expect(opt).toBeDisabled();
+    fireEvent.click(opt);
+    expect(onVote).not.toHaveBeenCalled();
+    expect(screen.getByText(/vote in Twitch chat/i)).toBeInTheDocument();
+  });
+
+  it('disables prediction outcomes and never fires onWager for a native prediction', () => {
+    const { onWager } = renderPanel({
+      prediction: makePrediction({ source: 'twitch_native' }),
+      engagement: { points_name: 'Points', balance: 1000 },
+    });
+    const out = screen.getByRole('button', { name: /Yes/ });
+    expect(out).toBeDisabled();
+    fireEvent.click(out);
+    expect(onWager).not.toHaveBeenCalled();
+  });
+});
+
+describe('EngagementPanel — All-Chat poll voting', () => {
+  it('lets an authed viewer vote on an ACTIVE All-Chat poll', () => {
+    const { onVote } = renderPanel({ poll: makePoll() });
+    const opt = screen.getByRole('button', { name: /Go/ });
+    expect(opt).not.toBeDisabled();
+    fireEvent.click(opt);
+    expect(onVote).toHaveBeenCalledWith(2);
+  });
+
+  it('does not offer voting to a logged-out viewer', () => {
+    const { onVote } = renderPanel({ poll: makePoll(), authed: false });
+    const opt = screen.getByRole('button', { name: /Rust/ });
+    expect(opt).toBeDisabled();
+    fireEvent.click(opt);
+    expect(onVote).not.toHaveBeenCalled();
+  });
+});
+
+describe('EngagementPanel — poll.allow_change (item 3)', () => {
+  const voted: ViewerEngagement = { points_name: 'Points', balance: 0, voted_option_id: 'opt-1' };
+
+  it('locks the options and shows a hint once a viewer has voted on an allow_change:false poll', () => {
+    const { onVote } = renderPanel({
+      poll: makePoll({ allow_change: false }),
+      engagement: voted,
+    });
+    // The option the viewer did NOT pick must be locked (no silent revert flicker).
+    const other = screen.getByRole('button', { name: /Go/ });
+    expect(other).toBeDisabled();
+    fireEvent.click(other);
+    expect(onVote).not.toHaveBeenCalled();
+    expect(screen.getByText(/locked in your vote/i)).toBeInTheDocument();
+  });
+
+  it('still allows re-voting when allow_change is true', () => {
+    const { onVote } = renderPanel({
+      poll: makePoll({ allow_change: true }),
+      engagement: voted,
+    });
+    const other = screen.getByRole('button', { name: /Go/ });
+    expect(other).not.toBeDisabled();
+    fireEvent.click(other);
+    expect(onVote).toHaveBeenCalledWith(2);
+    expect(screen.queryByText(/locked in your vote/i)).not.toBeInTheDocument();
+  });
+});
+
+describe('EngagementPanel — CANCELED prediction (item 6)', () => {
+  it('reveals a refund message during the cancel grace window instead of vanishing', () => {
+    renderPanel({
+      prediction: makePrediction({ state: 'CANCELED' }),
+      engagement: { points_name: 'Points', balance: 500, wager_outcome_id: 'out-1', wager_amount: 250 },
+    });
+    expect(screen.getByText(/Will they win\?/)).toBeInTheDocument();
+    expect(screen.getAllByText(/canceled/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/your wager was refunded/i)).toBeInTheDocument();
+  });
+});

--- a/tests/unit/logoutIntent.test.ts
+++ b/tests/unit/logoutIntent.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { markIntentionalLogout, wasIntentionalLogout, clearLogoutIntent } from '../../src/lib/storage';
+
+/**
+ * The intentional-logout marker (item 2): a deliberate "Sign out" writes a timestamp so the
+ * token-removal recovery listener stays silent, while a genuine expiry (no marker) still
+ * surfaces "Session expired". The check is a non-destructive PEEK — the single token removal
+ * fires storage.onChanged in every extension context (iframe + pop-out), so all must read the
+ * marker and stay silent; a destructive read would let a losing context still toast. Backed by
+ * a minimal in-memory chrome.storage.local mock.
+ */
+let store: Record<string, unknown> = {};
+beforeEach(() => {
+  store = {};
+  (globalThis as unknown as { chrome: unknown }).chrome = {
+    runtime: { lastError: undefined },
+    storage: {
+      local: {
+        get: (_keys: unknown, cb: (items: Record<string, unknown>) => void) => cb({ ...store }),
+        set: (items: Record<string, unknown>, cb: () => void) => {
+          Object.assign(store, items);
+          cb();
+        },
+        remove: (keys: string | string[], cb: () => void) => {
+          for (const k of Array.isArray(keys) ? keys : [keys]) delete store[k];
+          cb();
+        },
+      },
+    },
+  };
+});
+
+describe('logout intent marker', () => {
+  it('reads a fresh marker as intentional without consuming it (multi-context safe)', async () => {
+    await markIntentionalLogout();
+    expect(store.viewer_logout_intent).toBeTypeOf('number');
+
+    // A PEEK: every context that reads it within the window sees intentional=true, and the
+    // marker survives (so a second listener/window can't lose a race and toast).
+    expect(await wasIntentionalLogout()).toBe(true);
+    expect(await wasIntentionalLogout()).toBe(true);
+    expect(store.viewer_logout_intent).toBeTypeOf('number');
+  });
+
+  it('treats a missing marker (genuine expiry) as not intentional', async () => {
+    expect(await wasIntentionalLogout()).toBe(false);
+  });
+
+  it('clears the marker on login so it cannot outlive its logout', async () => {
+    await markIntentionalLogout();
+    await clearLogoutIntent();
+    expect(store.viewer_logout_intent).toBeUndefined();
+    expect(await wasIntentionalLogout()).toBe(false);
+  });
+
+  it('ignores a stale marker that outlived its honor window', async () => {
+    const nowSpy = vi.spyOn(Date, 'now');
+    nowSpy.mockReturnValue(1_000_000);
+    await markIntentionalLogout();
+    // Jump well past the 15s honor window.
+    nowSpy.mockReturnValue(1_000_000 + 60_000);
+    expect(await wasIntentionalLogout()).toBe(false);
+    nowSpy.mockRestore();
+  });
+});

--- a/tests/unit/logoutIntent.test.ts
+++ b/tests/unit/logoutIntent.test.ts
@@ -31,12 +31,12 @@ beforeEach(() => {
 });
 
 describe('logout intent marker', () => {
-  it('reads a fresh marker as intentional without consuming it (multi-context safe)', async () => {
+  it('reads a marker as intentional without consuming it (multi-context safe)', async () => {
     await markIntentionalLogout();
     expect(store.viewer_logout_intent).toBeTypeOf('number');
 
-    // A PEEK: every context that reads it within the window sees intentional=true, and the
-    // marker survives (so a second listener/window can't lose a race and toast).
+    // A PEEK: every context that reads it sees intentional=true, and the marker survives
+    // (so a second listener/window can't lose a race and toast).
     expect(await wasIntentionalLogout()).toBe(true);
     expect(await wasIntentionalLogout()).toBe(true);
     expect(store.viewer_logout_intent).toBeTypeOf('number');
@@ -53,13 +53,16 @@ describe('logout intent marker', () => {
     expect(await wasIntentionalLogout()).toBe(false);
   });
 
-  it('ignores a stale marker that outlived its honor window', async () => {
+  it('honors a marker regardless of age — it is cleared by login, not by elapsed time (item 8)', async () => {
     const nowSpy = vi.spyOn(Date, 'now');
     nowSpy.mockReturnValue(1_000_000);
     await markIntentionalLogout();
-    // Jump well past the 15s honor window.
-    nowSpy.mockReturnValue(1_000_000 + 60_000);
-    expect(await wasIntentionalLogout()).toBe(false);
+    // Jump far into the future: with no TTL, the marker is STILL honored. This is what closes
+    // the multi-context race — a >TTL-delayed onChanged in a second context can no longer read
+    // the marker as expired and wrongly toast "Session expired" after a deliberate logout. The
+    // marker is invalidated only by a subsequent login (see the clearLogoutIntent test above).
+    nowSpy.mockReturnValue(1_000_000 + 3_600_000);
+    expect(await wasIntentionalLogout()).toBe(true);
     nowSpy.mockRestore();
   });
 });

--- a/tests/unit/setup.ts
+++ b/tests/unit/setup.ts
@@ -1,0 +1,9 @@
+import '@testing-library/jest-dom/vitest';
+import { afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+
+// Unmount anything rendered by @testing-library/react between tests so DOM state
+// (and React trees) never leak from one test into the next.
+afterEach(() => {
+  cleanup();
+});

--- a/tests/unit/useEngagement.test.ts
+++ b/tests/unit/useEngagement.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useEngagement, wagerRejectionCopy } from '../../src/ui/hooks/useEngagement';
+import type { Poll, StreamerActive, ViewerEngagement } from '../../src/lib/types/engagement';
+
+// The hook talks only to engagementClient; mock it so we drive fetch resolution order.
+vi.mock('../../src/lib/engagementClient', () => ({
+  fetchActive: vi.fn(),
+  fetchMe: vi.fn(),
+  vote: vi.fn(),
+  wager: vi.fn(),
+  heartbeat: vi.fn(),
+}));
+import * as api from '../../src/lib/engagementClient';
+
+type Deferred<T> = { promise: Promise<T>; resolve: (v: T) => void };
+function deferred<T>(): Deferred<T> {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+const fetchActive = api.fetchActive as unknown as ReturnType<typeof vi.fn>;
+const fetchMe = api.fetchMe as unknown as ReturnType<typeof vi.fn>;
+const voteFn = api.vote as unknown as ReturnType<typeof vi.fn>;
+const heartbeat = api.heartbeat as unknown as ReturnType<typeof vi.fn>;
+
+function makePoll(over: Partial<Poll> = {}): Poll {
+  return {
+    id: 'poll-1',
+    source: 'allchat',
+    question: 'Q?',
+    state: 'ACTIVE',
+    allow_change: true,
+    options: [
+      { id: 'opt-1', idx: 1, label: 'A', votes: 1 },
+      { id: 'opt-2', idx: 2, label: 'B', votes: 2 },
+    ],
+    created_at: '2026-07-07T00:00:00Z',
+    ...over,
+  };
+}
+const round = (poll: Poll): StreamerActive => ({ points_name: 'Points', poll, prediction: null });
+
+beforeEach(() => {
+  fetchActive.mockReset();
+  fetchMe.mockReset();
+  voteFn.mockReset();
+  heartbeat.mockReset();
+  heartbeat.mockResolvedValue(null);
+});
+
+describe('wagerRejectionCopy table', () => {
+  it('maps every known reason to actionable copy', () => {
+    expect(wagerRejectionCopy('not_found', 'Points', 0)).toMatch(/no longer available/i);
+    expect(wagerRejectionCopy('not_active', 'Points', 0)).toMatch(/closed/i);
+    expect(wagerRejectionCopy('bad_outcome', 'Points', 0)).toMatch(/not valid/i);
+    expect(wagerRejectionCopy('already_wagered', 'Points', 0)).toMatch(/already placed/i);
+    expect(wagerRejectionCopy('native', 'Points', 0)).toMatch(/twitch channel points/i);
+  });
+
+  it('interpolates the points name and balance for insufficient funds', () => {
+    const copy = wagerRejectionCopy('insufficient', 'Gold', 1234);
+    expect(copy).toContain('Gold');
+    expect(copy).toContain('1,234');
+  });
+
+  it('falls back for an unknown reason', () => {
+    expect(wagerRejectionCopy(undefined, 'Points', 0)).toMatch(/not accepted/i);
+    expect(wagerRejectionCopy('brand_new_reason', 'Points', 0)).toMatch(/not accepted/i);
+  });
+});
+
+describe('refresh() transient vs definitive (item 1)', () => {
+  it('keeps the last round on a transient (undefined) fetch, clears on a definitive (null) fetch', async () => {
+    vi.useFakeTimers();
+    try {
+      fetchActive.mockResolvedValueOnce(round(makePoll())); // initial
+      const { result } = renderHook(() => useEngagement('streamer', false));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(result.current.poll?.id).toBe('poll-1');
+
+      // Transient failure — must NOT clear the round.
+      fetchActive.mockResolvedValueOnce(undefined);
+      act(() => result.current.onWsFrame());
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500);
+      });
+      expect(result.current.poll?.id).toBe('poll-1');
+
+      // Definitive "no round" — must clear.
+      fetchActive.mockResolvedValueOnce(null);
+      act(() => result.current.onWsFrame());
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500);
+      });
+      expect(result.current.poll).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('vote() optimistic rollback (item 1)', () => {
+  it('restores the prior voted_option_id when the vote fails', async () => {
+    const engaged: ViewerEngagement = { points_name: 'Points', balance: 10, voted_option_id: 'opt-1' };
+    fetchActive.mockResolvedValue(round(makePoll()));
+    fetchMe.mockResolvedValueOnce(engaged); // initial
+    fetchMe.mockResolvedValue(null); // post-error refresh keeps existing engagement
+
+    const { result } = renderHook(() => useEngagement('streamer', true));
+    await act(async () => {});
+    expect(result.current.engagement?.voted_option_id).toBe('opt-1');
+
+    voteFn.mockResolvedValueOnce({ error: 'VOTE_FAILED' });
+    await act(async () => {
+      result.current.vote(2);
+    });
+    // Optimistic highlight rolled back to the prior choice, not left on opt-2.
+    expect(result.current.engagement?.voted_option_id).toBe('opt-1');
+  });
+});
+
+describe('vote() {status:"ok"} sentinel guard (item 5)', () => {
+  it('does not overwrite the live poll with a bodyless accept response', async () => {
+    fetchMe.mockResolvedValue(null);
+    fetchActive.mockResolvedValueOnce(round(makePoll())); // initial
+    const { result } = renderHook(() => useEngagement('streamer', false));
+    await act(async () => {});
+    expect(result.current.poll?.options?.length).toBe(2);
+
+    // Backend accepted the vote but its GetPoll follow-up failed → 200 {status:"ok"}.
+    // Hold the post-vote refresh pending so we observe the state the vote itself left.
+    const activeAfter = deferred<StreamerActive | null | undefined>();
+    fetchActive.mockReturnValueOnce(activeAfter.promise);
+    voteFn.mockResolvedValueOnce({ poll: { status: 'ok' } as unknown as Poll });
+
+    await act(async () => {
+      result.current.vote(2);
+    });
+    // The sentinel (no id) must be ignored — the panel would otherwise blank.
+    expect(result.current.poll?.id).toBe('poll-1');
+    expect(result.current.poll?.options?.length).toBe(2);
+
+    await act(async () => {
+      activeAfter.resolve(round(makePoll()));
+    });
+  });
+});
+
+describe('auth toggle does not blank the public round (item 4)', () => {
+  it('keeps poll/prediction rendered while the viewer snapshot refreshes on login', async () => {
+    fetchActive.mockResolvedValueOnce(round(makePoll())); // initial (logged out)
+    fetchMe.mockResolvedValue({ points_name: 'Points', balance: 5 });
+    const { result, rerender } = renderHook(({ authed }) => useEngagement('streamer', authed), {
+      initialProps: { authed: false },
+    });
+    await act(async () => {});
+    expect(result.current.poll?.id).toBe('poll-1');
+
+    // On login the public round must stay on screen; only the viewer snapshot refetches.
+    const activeAfter = deferred<StreamerActive | null | undefined>();
+    fetchActive.mockReturnValueOnce(activeAfter.promise);
+    rerender({ authed: true });
+    // Still visible even though the refetch is in flight (no pre-clear).
+    expect(result.current.poll?.id).toBe('poll-1');
+
+    await act(async () => {
+      activeAfter.resolve(round(makePoll()));
+    });
+    expect(result.current.poll?.id).toBe('poll-1');
+  });
+});
+
+describe('stale refresh cannot revert a fresh vote (item 1 sequencing)', () => {
+  it('ignores an in-flight pre-vote refresh that resolves after the vote', async () => {
+    vi.useFakeTimers();
+    try {
+      const activeQ: Deferred<StreamerActive | null | undefined>[] = [];
+      const meQ: Deferred<ViewerEngagement | null>[] = [];
+      fetchActive.mockImplementation(() => {
+        const d = deferred<StreamerActive | null | undefined>();
+        activeQ.push(d);
+        return d.promise;
+      });
+      fetchMe.mockImplementation(() => {
+        const d = deferred<ViewerEngagement | null>();
+        meQ.push(d);
+        return d.promise;
+      });
+
+      const { result } = renderHook(() => useEngagement('streamer', true));
+      // Initial refresh (index 0).
+      await act(async () => {
+        activeQ[0].resolve(round(makePoll()));
+        meQ[0].resolve({ points_name: 'Points', balance: 10, voted_option_id: undefined });
+      });
+      expect(result.current.poll?.id).toBe('poll-1');
+
+      // A pre-vote refresh goes in flight (index 1) and is left PENDING (the stale one).
+      act(() => result.current.onWsFrame());
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500);
+      });
+      expect(activeQ.length).toBe(2);
+
+      // The viewer votes: optimistic highlight → opt-2, then the accepted vote resolves and
+      // triggers its own reconciling refresh (index 2).
+      voteFn.mockResolvedValueOnce({ poll: makePoll() });
+      await act(async () => {
+        result.current.vote(2);
+      });
+      expect(result.current.engagement?.voted_option_id).toBe('opt-2');
+
+      // Now the STALE pre-vote refresh finally lands with the old (no-vote) snapshot.
+      await act(async () => {
+        activeQ[1].resolve(round(makePoll()));
+        meQ[1].resolve({ points_name: 'Points', balance: 10, voted_option_id: undefined });
+      });
+      // It must NOT wipe the fresh vote.
+      expect(result.current.engagement?.voted_option_id).toBe('opt-2');
+
+      // Reconciling refresh (index 2) confirms the vote server-side.
+      if (activeQ[2]) {
+        await act(async () => {
+          activeQ[2].resolve(round(makePoll()));
+          meQ[2]?.resolve({ points_name: 'Points', balance: 10, voted_option_id: 'opt-2' });
+        });
+      }
+      expect(result.current.engagement?.voted_option_id).toBe('opt-2');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("isolates vote()'s own seq bump: a stale refresh landing DURING the vote round-trip can't revert it", async () => {
+    vi.useFakeTimers();
+    try {
+      const activeQ: Deferred<StreamerActive | null | undefined>[] = [];
+      const meQ: Deferred<ViewerEngagement | null>[] = [];
+      fetchActive.mockImplementation(() => {
+        const d = deferred<StreamerActive | null | undefined>();
+        activeQ.push(d);
+        return d.promise;
+      });
+      fetchMe.mockImplementation(() => {
+        const d = deferred<ViewerEngagement | null>();
+        meQ.push(d);
+        return d.promise;
+      });
+
+      const { result } = renderHook(() => useEngagement('streamer', true));
+      await act(async () => {
+        activeQ[0].resolve(round(makePoll()));
+        meQ[0].resolve({ points_name: 'Points', balance: 10, voted_option_id: undefined });
+      });
+
+      // A pre-vote refresh goes in flight (index 1), left PENDING.
+      act(() => result.current.onWsFrame());
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500);
+      });
+      expect(activeQ.length).toBe(2);
+
+      // Vote, but hold the vote REQUEST itself pending — so its trailing refresh has NOT been
+      // issued yet. Only vote()'s own up-front seqRef bump can protect the optimistic vote here.
+      const voteResp = deferred<{ poll?: Poll; error?: string }>();
+      voteFn.mockReturnValueOnce(voteResp.promise);
+      await act(async () => {
+        result.current.vote(2);
+      });
+      expect(result.current.engagement?.voted_option_id).toBe('opt-2');
+
+      // Stale pre-vote refresh lands mid-round-trip with the old no-vote snapshot.
+      await act(async () => {
+        activeQ[1].resolve(round(makePoll()));
+        meQ[1].resolve({ points_name: 'Points', balance: 10, voted_option_id: undefined });
+      });
+      // Without vote()'s seqRef bump this would revert to undefined; it must stay opt-2.
+      expect(result.current.engagement?.voted_option_id).toBe('opt-2');
+
+      // Vote finally resolves and reconciles.
+      await act(async () => {
+        voteResp.resolve({ poll: makePoll() });
+      });
+      if (activeQ[2]) {
+        await act(async () => {
+          activeQ[2].resolve(round(makePoll()));
+          meQ[2]?.resolve({ points_name: 'Points', balance: 10, voted_option_id: 'opt-2' });
+        });
+      }
+      expect(result.current.engagement?.voted_option_id).toBe('opt-2');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/tests/unit/useEngagement.test.ts
+++ b/tests/unit/useEngagement.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useEngagement, wagerRejectionCopy } from '../../src/ui/hooks/useEngagement';
-import type { Poll, StreamerActive, ViewerEngagement } from '../../src/lib/types/engagement';
+import type { Poll, Prediction, StreamerActive, ViewerEngagement } from '../../src/lib/types/engagement';
 
 // The hook talks only to engagementClient; mock it so we drive fetch resolution order.
 vi.mock('../../src/lib/engagementClient', () => ({
@@ -25,6 +25,7 @@ function deferred<T>(): Deferred<T> {
 const fetchActive = api.fetchActive as unknown as ReturnType<typeof vi.fn>;
 const fetchMe = api.fetchMe as unknown as ReturnType<typeof vi.fn>;
 const voteFn = api.vote as unknown as ReturnType<typeof vi.fn>;
+const wagerFn = api.wager as unknown as ReturnType<typeof vi.fn>;
 const heartbeat = api.heartbeat as unknown as ReturnType<typeof vi.fn>;
 
 function makePoll(over: Partial<Poll> = {}): Poll {
@@ -44,10 +45,27 @@ function makePoll(over: Partial<Poll> = {}): Poll {
 }
 const round = (poll: Poll): StreamerActive => ({ points_name: 'Points', poll, prediction: null });
 
+function makePrediction(over: Partial<Prediction> = {}): Prediction {
+  return {
+    id: 'pred-1',
+    source: 'allchat',
+    title: 'Win?',
+    state: 'ACTIVE',
+    outcomes: [
+      { id: 'out-1', idx: 1, label: 'Yes', total_points: 100, entrants: 2 },
+      { id: 'out-2', idx: 2, label: 'No', total_points: 50, entrants: 1 },
+    ],
+    created_at: '2026-07-07T00:00:00Z',
+    ...over,
+  };
+}
+const roundP = (prediction: Prediction): StreamerActive => ({ points_name: 'Points', poll: null, prediction });
+
 beforeEach(() => {
   fetchActive.mockReset();
   fetchMe.mockReset();
   voteFn.mockReset();
+  wagerFn.mockReset();
   heartbeat.mockReset();
   heartbeat.mockResolvedValue(null);
 });
@@ -294,6 +312,319 @@ describe('stale refresh cannot revert a fresh vote (item 1 sequencing)', () => {
         });
       }
       expect(result.current.engagement?.voted_option_id).toBe('opt-2');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('wager() execution (item 3)', () => {
+  it('applies the returned balance and prediction on a successful wager', async () => {
+    fetchActive.mockResolvedValueOnce(roundP(makePrediction())); // initial
+    fetchMe.mockResolvedValueOnce({ points_name: 'Points', balance: 1000 }); // initial
+    const { result } = renderHook(() => useEngagement('streamer', true));
+    await act(async () => {});
+    expect(result.current.prediction?.id).toBe('pred-1');
+    expect(result.current.engagement?.balance).toBe(1000);
+
+    // Hold the reconciling refresh pending so we observe exactly what wager()'s handler wrote.
+    const activeAfter = deferred<StreamerActive | null | undefined>();
+    fetchActive.mockReturnValueOnce(activeAfter.promise);
+    fetchMe.mockResolvedValue(null);
+
+    wagerFn.mockResolvedValueOnce({
+      balance: 500,
+      prediction: makePrediction({
+        outcomes: [
+          { id: 'out-1', idx: 1, label: 'Yes', total_points: 600, entrants: 3 },
+          { id: 'out-2', idx: 2, label: 'No', total_points: 50, entrants: 1 },
+        ],
+      }),
+    });
+    await act(async () => {
+      result.current.wager(1, 500);
+    });
+    expect(wagerFn).toHaveBeenCalledWith('streamer', 'pred-1', 1, 500);
+    expect(result.current.engagement?.balance).toBe(500);
+    expect(result.current.prediction?.outcomes[0].total_points).toBe(600);
+    expect(result.current.notice).toBeNull();
+
+    await act(async () => {
+      activeAfter.resolve(roundP(makePrediction()));
+    });
+  });
+
+  it('rejects a client-side over-balance wager without calling the API', async () => {
+    fetchActive.mockResolvedValue(roundP(makePrediction()));
+    fetchMe.mockResolvedValue({ points_name: 'Gold', balance: 100 });
+    const { result } = renderHook(() => useEngagement('streamer', true));
+    await act(async () => {});
+
+    await act(async () => {
+      result.current.wager(1, 500); // 500 > balance 100
+    });
+    expect(wagerFn).not.toHaveBeenCalled();
+    expect(result.current.notice).toMatch(/not enough gold/i);
+    expect(result.current.notice).toContain('100');
+    expect(result.current.engagement?.balance).toBe(100);
+  });
+
+  it('surfaces actionable rejection copy and leaves the balance unchanged when the wager bounces', async () => {
+    fetchActive.mockResolvedValue(roundP(makePrediction()));
+    fetchMe.mockResolvedValue({ points_name: 'Points', balance: 1000 });
+    const { result } = renderHook(() => useEngagement('streamer', true));
+    await act(async () => {});
+    expect(result.current.engagement?.balance).toBe(1000);
+
+    wagerFn.mockResolvedValueOnce({ error: 'WAGER_FAILED', reason: 'already_wagered' });
+    await act(async () => {
+      result.current.wager(1, 100);
+    });
+    expect(result.current.notice).toMatch(/already placed/i);
+    expect(result.current.engagement?.balance).toBe(1000);
+  });
+});
+
+describe('wager() insufficient copy reflects the fresh balance (item 5)', () => {
+  it('shows the current balance in the rejection, not the stale submit-time value', async () => {
+    vi.useFakeTimers();
+    try {
+      fetchActive.mockResolvedValue(roundP(makePrediction()));
+      fetchMe.mockResolvedValueOnce({ points_name: 'Gold', balance: 1000 }); // initial
+      const { result } = renderHook(() => useEngagement('streamer', true));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(result.current.engagement?.balance).toBe(1000);
+
+      // Submit a wager that passes the client-side check (100 <= 1000), held in flight.
+      const wagerResp = deferred<{ balance?: number; prediction?: Prediction; error?: string; reason?: string }>();
+      wagerFn.mockReturnValueOnce(wagerResp.promise);
+      await act(async () => {
+        result.current.wager(1, 100);
+      });
+
+      // While the wager is in flight, an off-band refresh drops the balance to 50.
+      fetchMe.mockResolvedValueOnce({ points_name: 'Gold', balance: 50 });
+      act(() => result.current.onWsFrame());
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500);
+      });
+      expect(result.current.engagement?.balance).toBe(50);
+
+      // The server now rejects the wager as insufficient — the copy must show the fresh 50,
+      // not the 1,000 captured when the (memoized) wager callback was created.
+      await act(async () => {
+        wagerResp.resolve({ error: 'WAGER_FAILED', reason: 'insufficient' });
+      });
+      expect(result.current.notice).toContain('50');
+      expect(result.current.notice).not.toContain('1,000');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('stale refresh cannot revert a fresh wager (item 1 sequencing)', () => {
+  it('ignores an in-flight pre-wager refresh that resolves after the wager', async () => {
+    vi.useFakeTimers();
+    try {
+      const activeQ: Deferred<StreamerActive | null | undefined>[] = [];
+      const meQ: Deferred<ViewerEngagement | null>[] = [];
+      fetchActive.mockImplementation(() => {
+        const d = deferred<StreamerActive | null | undefined>();
+        activeQ.push(d);
+        return d.promise;
+      });
+      fetchMe.mockImplementation(() => {
+        const d = deferred<ViewerEngagement | null>();
+        meQ.push(d);
+        return d.promise;
+      });
+
+      const { result } = renderHook(() => useEngagement('streamer', true));
+      // Initial refresh (index 0).
+      await act(async () => {
+        activeQ[0].resolve(roundP(makePrediction()));
+        meQ[0].resolve({ points_name: 'Points', balance: 1000 });
+      });
+      expect(result.current.engagement?.balance).toBe(1000);
+
+      // A pre-wager refresh goes in flight (index 1) and is left PENDING (the stale one).
+      act(() => result.current.onWsFrame());
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500);
+      });
+      expect(activeQ.length).toBe(2);
+
+      // The viewer wagers: it resolves with the post-wager balance and triggers its own
+      // reconciling refresh (index 2).
+      wagerFn.mockResolvedValueOnce({ balance: 500, prediction: makePrediction() });
+      await act(async () => {
+        result.current.wager(1, 500);
+      });
+      expect(result.current.engagement?.balance).toBe(500);
+
+      // Now the STALE pre-wager refresh finally lands with the old (pre-wager) balance.
+      await act(async () => {
+        activeQ[1].resolve(roundP(makePrediction()));
+        meQ[1].resolve({ points_name: 'Points', balance: 1000 });
+      });
+      // It must NOT wipe the fresh wager balance.
+      expect(result.current.engagement?.balance).toBe(500);
+
+      // Reconciling refresh (index 2) confirms the wager server-side.
+      if (activeQ[2]) {
+        await act(async () => {
+          activeQ[2].resolve(roundP(makePrediction()));
+          meQ[2]?.resolve({ points_name: 'Points', balance: 500, wager_outcome_id: 'out-1', wager_amount: 500 });
+        });
+      }
+      expect(result.current.engagement?.balance).toBe(500);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("isolates wager()'s own seq bump: a stale refresh landing DURING the round-trip can't overwrite the balance", async () => {
+    vi.useFakeTimers();
+    try {
+      const activeQ: Deferred<StreamerActive | null | undefined>[] = [];
+      const meQ: Deferred<ViewerEngagement | null>[] = [];
+      fetchActive.mockImplementation(() => {
+        const d = deferred<StreamerActive | null | undefined>();
+        activeQ.push(d);
+        return d.promise;
+      });
+      fetchMe.mockImplementation(() => {
+        const d = deferred<ViewerEngagement | null>();
+        meQ.push(d);
+        return d.promise;
+      });
+
+      const { result } = renderHook(() => useEngagement('streamer', true));
+      await act(async () => {
+        activeQ[0].resolve(roundP(makePrediction()));
+        meQ[0].resolve({ points_name: 'Points', balance: 1000 });
+      });
+      expect(result.current.engagement?.balance).toBe(1000);
+
+      // A pre-wager refresh goes in flight (index 1), left PENDING.
+      act(() => result.current.onWsFrame());
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500);
+      });
+      expect(activeQ.length).toBe(2);
+
+      // Wager, but hold the wager REQUEST itself pending — so its trailing reconciling refresh
+      // has NOT been issued yet. Only wager()'s own up-front seqRef bump (line 243) can protect
+      // the balance here.
+      const wagerResp = deferred<{ balance?: number; prediction?: Prediction; error?: string }>();
+      wagerFn.mockReturnValueOnce(wagerResp.promise);
+      await act(async () => {
+        result.current.wager(1, 400);
+      });
+
+      // The stale pre-wager refresh lands mid-round-trip carrying a DIVERGENT balance. That
+      // divergence is the instrument that makes suppression observable — wager, unlike vote,
+      // writes no optimistic state of its own. Without wager()'s seq bump this stale snapshot
+      // would be applied (balance → 7777); with it, the refresh bails.
+      await act(async () => {
+        activeQ[1].resolve(roundP(makePrediction()));
+        meQ[1].resolve({ points_name: 'Points', balance: 7777 });
+      });
+      expect(result.current.engagement?.balance).toBe(1000);
+
+      // Wager finally resolves and reconciles to the true post-wager balance.
+      await act(async () => {
+        wagerResp.resolve({ balance: 600, prediction: makePrediction() });
+      });
+      expect(result.current.engagement?.balance).toBe(600);
+      if (activeQ[2]) {
+        await act(async () => {
+          activeQ[2].resolve(roundP(makePrediction()));
+          meQ[2]?.resolve({ points_name: 'Points', balance: 600, wager_outcome_id: 'out-1', wager_amount: 400 });
+        });
+      }
+      expect(result.current.engagement?.balance).toBe(600);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('heartbeat balance write is sequence-guarded (item 1)', () => {
+  it('does not clobber a fresh wager balance with a stale heartbeat value', async () => {
+    vi.useFakeTimers();
+    try {
+      const activeQ: Deferred<StreamerActive | null | undefined>[] = [];
+      const meQ: Deferred<ViewerEngagement | null>[] = [];
+      fetchActive.mockImplementation(() => {
+        const d = deferred<StreamerActive | null | undefined>();
+        activeQ.push(d);
+        return d.promise;
+      });
+      fetchMe.mockImplementation(() => {
+        const d = deferred<ViewerEngagement | null>();
+        meQ.push(d);
+        return d.promise;
+      });
+      // The heartbeat fires but resolves LATE, carrying the stale pre-wager balance.
+      const hb = deferred<number | null>();
+      heartbeat.mockReturnValueOnce(hb.promise);
+
+      const { result } = renderHook(() => useEngagement('streamer', true));
+      await act(async () => {
+        activeQ[0].resolve(roundP(makePrediction()));
+        meQ[0].resolve({ points_name: 'Points', balance: 1000 });
+      });
+      expect(result.current.engagement?.balance).toBe(1000);
+
+      // Advance to fire the 60s heartbeat (it captures seqRef *before* the wager), held pending.
+      // The 15s live-round interval also fires here; its refreshes are left pending and don't
+      // matter — the point is only that the heartbeat captured its seq before the wager.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_000);
+      });
+
+      // Viewer wagers → balance 500, advancing seqRef past the heartbeat's captured value.
+      wagerFn.mockResolvedValueOnce({ balance: 500, prediction: makePrediction() });
+      await act(async () => {
+        result.current.wager(1, 500);
+      });
+      expect(result.current.engagement?.balance).toBe(500);
+
+      // The stale heartbeat finally resolves carrying the pre-wager 1000 — it must be dropped.
+      await act(async () => {
+        hb.resolve(1000);
+      });
+      expect(result.current.engagement?.balance).toBe(500);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('applies the balance the heartbeat returns in place, without an extra /active fetch when idle', async () => {
+    vi.useFakeTimers();
+    try {
+      fetchActive.mockResolvedValue(null); // no live round → no 15s polling, mirrors an idle viewer
+      fetchMe.mockResolvedValueOnce({ points_name: 'Points', balance: 1000 });
+      heartbeat.mockResolvedValueOnce(1200); // watch-time award raised the balance
+      const { result } = renderHook(() => useEngagement('streamer', true));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+      expect(result.current.engagement?.balance).toBe(1000);
+      const activeCallsBefore = fetchActive.mock.calls.length;
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_000);
+      });
+      expect(heartbeat).toHaveBeenCalledTimes(1);
+      // Balance updated straight from the heartbeat's own return value...
+      expect(result.current.engagement?.balance).toBe(1200);
+      // ...with NO extra /active fetch — the "no polling when nothing is live" design holds.
+      expect(fetchActive.mock.calls.length).toBe(activeCallsBefore);
     } finally {
       vi.useRealTimers();
     }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Unit/component test harness (jsdom + @testing-library/react).
+ *
+ * Complements the Playwright suite in tests/*.spec.ts, which exercises the packed
+ * extension end-to-end in a real browser but cannot reach the pure logic in the
+ * engagement hook/panel (a live round needs a running engagement-service). These
+ * fast unit tests cover that behavior. Playwright is scoped away from tests/unit via
+ * testIgnore so the two runners never collide.
+ */
+export default defineConfig({
+  esbuild: { jsx: 'automatic' },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    include: ['tests/unit/**/*.test.{ts,tsx}'],
+    setupFiles: ['tests/unit/setup.ts'],
+  },
+});


### PR DESCRIPTION
## Summary

Integrates all-chat **PR #524** (cross-platform polls, predictions & viewer points) into the extension. The streamer's live All-Chat poll/prediction now renders in the chat overlay, and a signed-in viewer can **vote or wager points with one click** — a proper interactive UI, not chat-command spam.

## How it works
- The extension attaches to a stream by **streamer username** and never learns the overlay id. It uses the new **streamer-keyed endpoints** (`/api/v1/engagement/streamers/:username/{active,me,vote,wager,heartbeat}`) added in all-chat under **ADR-0031**, which resolve username → public overlay server-side.
- `poll_update` / `prediction_update` frames already arrive on the existing chat WebSocket (viewer subscription); they act as a "refetch now" signal. Authoritative state comes from the HTTP endpoints (which apply All-Chat-over-native display precedence).
- All engagement HTTP goes **through the service worker** (the documented API proxy): it holds the viewer JWT, so background fetches pass the gateway `OriginCheck` and the overlay id never reaches a page context.
- Twitch-**native** mirrored rounds render **read-only** (they settle in Twitch Channel Points).

## Changes
- `useEngagement` hook + `EngagementPanel` component, mounted in `ChatContainer` above the message list
- Service-worker engagement proxy handlers + `engagementClient` (talks to the SW via `chrome.runtime.sendMessage`)
- `storage.onChanged` listener so an expired token recovers the UI mid-session
- Static integration spec guarding the wiring **and the overlay-id secrecy invariant**
- Version bump 1.6.4 → **1.7.0**; README

## Requires
The backend companion on the all-chat PR #524 branch (`feature/523-engagement-polls-predictions-points`) — the streamer-keyed endpoints + ADR-0031. Ship that first.

## Verification
- `npm run type-check` ✅, `npm run build` ✅, engagement integration spec 7/7 ✅
- Reviewed adversarially; all confirmed findings fixed (expired-token recovery, ended-round clear on 404 vs transient, optimistic-vote rollback, wager-input retention, dead ref removed)
- A true end-to-end (a real round appearing + a vote landing) needs a running engagement-service and a streamer with a public overlay running a round — not reproducible in CI, so it is covered by the static wiring spec here and by manual verification against a production build.