### PR TITLE
fix(reconnect): harden WebSocket reconnection against long redeploys (#543 batch A)

### DIFF
--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -45,6 +45,7 @@ import {
   setNameGradient,
   DEFAULT_SETTINGS,
 } from '../lib/storage';
+import { computeBackoffDelay } from '../lib/backoff';
 
 // Registry of connected pop-out window ports
 const popoutPorts: Set<chrome.runtime.Port> = new Set();
@@ -52,9 +53,10 @@ const popoutPorts: Set<chrome.runtime.Port> = new Set();
 // WebSocket connection
 let wsConnection: WebSocket | null = null;
 let wsStreamerUsername: string | null = null;
+// Reconnect attempt counter driving the exponential backoff. There is no
+// maximum — like the web overlay, the extension retries indefinitely so a
+// redeployment longer than the old ~55s cap no longer leaves the socket dead.
 let wsReconnectAttempts = 0;
-const WS_MAX_RECONNECT_ATTEMPTS = 10;
-const WS_RECONNECT_DELAY_MS = 1000; // Base delay, will be multiplied by attempt number
 let reconnectTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
 
@@ -67,6 +69,18 @@ const KEEPALIVE_ALARM = 'allchat-ws-keepalive';
 // chrome.storage.session key for persisting the active streamer across
 // service worker restarts. Session storage is cleared when the browser closes.
 const SESSION_STREAMER_KEY = 'ws_active_streamer';
+
+// chrome.storage.session key persisting the reconnect attempt counter. Without
+// this, an MV3 worker evicted mid-outage restarts at attempt 0 on wake, so its
+// backoff resets to ~1s and every evicted worker hammers the server in lockstep
+// on recovery. Persisting it lets a restarted worker resume the existing
+// backoff. Session storage (not local) so it's cleared when the browser closes.
+const SESSION_RECONNECT_ATTEMPTS_KEY = 'ws_reconnect_attempts';
+
+/** Mirror the in-memory reconnect counter to session storage (best-effort). */
+function persistReconnectAttempts(): void {
+  chrome.storage.session.set({ [SESSION_RECONNECT_ATTEMPTS_KEY]: wsReconnectAttempts }).catch(() => {});
+}
 
 /**
  * Locate the content-script-owning tab for a pop-out native-send request.
@@ -145,9 +159,11 @@ chrome.runtime.onConnect.addListener((port) => {
 // Restore WebSocket connection if the service worker was restarted while a
 // session was active (e.g. due to MV3 30-second idle eviction).
 (async () => {
-  const result = await chrome.storage.session.get(SESSION_STREAMER_KEY);
+  const result = await chrome.storage.session.get([SESSION_STREAMER_KEY, SESSION_RECONNECT_ATTEMPTS_KEY]);
   const savedStreamer = result[SESSION_STREAMER_KEY] as string | undefined;
   if (savedStreamer) {
+    // Resume the existing backoff rather than restarting at attempt 0.
+    wsReconnectAttempts = (result[SESSION_RECONNECT_ATTEMPTS_KEY] as number | undefined) ?? 0;
     console.log('[AllChat] Service worker restarted — restoring connection for:', savedStreamer);
     connectWebSocket(savedStreamer);
   }
@@ -338,8 +354,7 @@ chrome.runtime.onMessage.addListener((message: ExtensionMessage, sender, sendRes
             success: true,
             data: {
               state: currentConnectionState,
-              attempts: wsReconnectAttempts,
-              maxAttempts: WS_MAX_RECONNECT_ATTEMPTS
+              attempts: wsReconnectAttempts
             }
           });
           break;
@@ -508,6 +523,7 @@ async function connectWebSocket(streamerUsername: string): Promise<void> {
   wsConnection.onopen = async () => {
     console.log('[AllChat] WebSocket connected successfully!');
     wsReconnectAttempts = 0;
+    persistReconnectAttempts();
     startWebSocketHeartbeat();
 
     // Authenticate via first message instead of URL param
@@ -519,6 +535,7 @@ async function connectWebSocket(streamerUsername: string): Promise<void> {
     // Update extension badge
     chrome.action.setBadgeBackgroundColor({ color: '#00ff00' });
     chrome.action.setBadgeText({ text: '✓' });
+    chrome.action.setTitle({ title: 'AllChat' });
 
     // Broadcast connected state
     broadcastConnectionState('connected');
@@ -574,30 +591,31 @@ async function connectWebSocket(streamerUsername: string): Promise<void> {
       return;
     }
 
-    // Attempt reconnection
-    if (wsReconnectAttempts < WS_MAX_RECONNECT_ATTEMPTS) {
-      wsReconnectAttempts++;
-      const delay = WS_RECONNECT_DELAY_MS * wsReconnectAttempts;
-      console.log(`[AllChat] Reconnecting in ${delay}ms (attempt ${wsReconnectAttempts}/${WS_MAX_RECONNECT_ATTEMPTS})`);
+    // Attempt reconnection — no attempt cap (matches the web overlay, which
+    // retries indefinitely). Exponential backoff with jitter bounds the retry
+    // rate, so a redeploy longer than the old ~55s / 10-attempt cap no longer
+    // leaves the socket permanently dead.
+    wsReconnectAttempts++;
+    persistReconnectAttempts();
+    const delay = computeBackoffDelay(wsReconnectAttempts);
+    console.log(`[AllChat] Reconnecting in ${Math.round(delay)}ms (attempt ${wsReconnectAttempts})`);
 
-      // Broadcast reconnecting state with countdown
-      broadcastConnectionState('reconnecting', {
-        reconnectIn: delay,
-      });
+    // Reconnecting badge (orange) + tooltip — visible signal that the socket
+    // is down and retrying, rather than the ambiguous cleared badge.
+    chrome.action.setBadgeBackgroundColor({ color: '#ff9900' });
+    chrome.action.setBadgeText({ text: '↻' });
+    chrome.action.setTitle({ title: 'AllChat — reconnecting…' });
 
-      reconnectTimeoutId = setTimeout(() => {
-        if (wsStreamerUsername) {
-          connectWebSocket(wsStreamerUsername);
-        }
-      }, delay);
-    } else {
-      console.error('[AllChat] Max reconnection attempts reached');
-      chrome.action.setBadgeBackgroundColor({ color: '#ff0000' });
-      chrome.action.setBadgeText({ text: '✗' });
+    // Broadcast reconnecting state with countdown
+    broadcastConnectionState('reconnecting', {
+      reconnectIn: delay,
+    });
 
-      // Broadcast failed state
-      broadcastConnectionState('failed');
-    }
+    reconnectTimeoutId = setTimeout(() => {
+      if (wsStreamerUsername) {
+        connectWebSocket(wsStreamerUsername);
+      }
+    }, delay);
   };
 }
 
@@ -676,7 +694,6 @@ function broadcastConnectionState(state: ConnectionState, details?: any): void {
           data: {
             state,
             attempts: wsReconnectAttempts,
-            maxAttempts: WS_MAX_RECONNECT_ATTEMPTS,
             ...details,
           },
           streamer: wsStreamerUsername,
@@ -693,7 +710,6 @@ function broadcastConnectionState(state: ConnectionState, details?: any): void {
     data: {
       state,
       attempts: wsReconnectAttempts,
-      maxAttempts: WS_MAX_RECONNECT_ATTEMPTS,
       ...details,
     },
   });

--- a/src/lib/backoff.ts
+++ b/src/lib/backoff.ts
@@ -1,0 +1,37 @@
+/**
+ * This file is part of All-Chat Extension.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Exponential backoff with jitter for WebSocket reconnection.
+ *
+ * Ported verbatim from the web overlay's computeBackoffDelay
+ * (all-chat: frontend/src/lib/utils/overlayStreamCore.ts) so the extension and
+ * the overlay reconnect identically: min(1000 * 1.5^attempts, 30000) +
+ * [0, 1000) ms of jitter.
+ *
+ * The 30s ceiling bounds server load during a long outage; the jitter
+ * de-synchronizes a thundering herd of overlays/extensions all reconnecting at
+ * once after a rolling redeploy. `rng` is injectable so tests can pin the
+ * jitter. There is deliberately no attempt cap — callers retry indefinitely.
+ */
+export function computeBackoffDelay(attempts: number, rng: () => number = Math.random): number {
+  const baseDelay = 1000;
+  const maxDelay = 30000;
+  const jitter = rng() * 1000;
+  return Math.min(baseDelay * Math.pow(1.5, attempts), maxDelay) + jitter;
+}

--- a/src/ui/components/ChatContainer.tsx
+++ b/src/ui/components/ChatContainer.tsx
@@ -141,7 +141,6 @@ type ConnectionState = 'connected' | 'connecting' | 'reconnecting' | 'disconnect
 interface ConnectionStatus {
   state: ConnectionState;
   attempts?: number;
-  maxAttempts?: number;
   reconnectIn?: number;
   error?: string;
   message?: string;
@@ -928,7 +927,7 @@ export default function ChatContainer({ platform, streamer, displayName, twitchC
                           </div>
                         </>
                       ) : (
-                        <span className="text-sm text-red-200">Connection failed after {connectionStatus.maxAttempts} attempts</span>
+                        <span className="text-sm text-red-200">{connectionStatus.message || 'Connection failed'}</span>
                       )}
                     </div>
                     <button

--- a/tests/unit/backoff.test.ts
+++ b/tests/unit/backoff.test.ts
@@ -1,0 +1,45 @@
+/**
+ * This file is part of All-Chat Extension.
+ * Copyright (C) 2026 caesarakalaeii
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { computeBackoffDelay } from '../../src/lib/backoff';
+
+describe('computeBackoffDelay', () => {
+  // Pin the jitter to 0 so the deterministic part is testable.
+  const noJitter = () => 0;
+
+  it('grows exponentially (1.5^attempts * 1000) before the ceiling', () => {
+    expect(computeBackoffDelay(0, noJitter)).toBe(1000);
+    expect(computeBackoffDelay(1, noJitter)).toBe(1500);
+    expect(computeBackoffDelay(2, noJitter)).toBe(2250);
+    expect(computeBackoffDelay(3, noJitter)).toBe(3375);
+  });
+
+  it('caps the base delay at 30000ms regardless of attempt count', () => {
+    // 1.5^30 * 1000 is far past 30s; large attempt counts must not overflow it.
+    expect(computeBackoffDelay(30, noJitter)).toBe(30000);
+    expect(computeBackoffDelay(1000, noJitter)).toBe(30000);
+  });
+
+  it('adds [0,1000) ms of jitter on top of the (capped) base', () => {
+    expect(computeBackoffDelay(0, () => 0.5)).toBe(1500); // 1000 + 500
+    expect(computeBackoffDelay(1000, () => 0.999)).toBeCloseTo(30999, 0); // ceiling + jitter
+    // Jitter is strictly below 1000ms.
+    expect(computeBackoffDelay(0, () => 0.9999)).toBeLessThan(2000);
+  });
+});


### PR DESCRIPTION
Addresses **batch A** (client-only) of caesarakalaeii/all-chat#543.

## Problem
`service-worker.ts` gave up permanently after **10 linear-backoff attempts (~55s)**. Any redeploy or outage longer than that left the overlay/chat monitor silently dead until the streamer manually reset the extension — even though the web overlay (`useOverlayStream`) retries forever.

## Changes (client-only)
- **Remove the hard 10-attempt cap** — reconnect indefinitely, matching the web overlay. (issue item #1)
- **Exponential backoff + jitter** — ported `computeBackoffDelay()` (min(1000·1.5ⁿ, 30000) + [0,1000)ms jitter) **verbatim** from the overlay's `overlayStreamCore.ts` into a shared, unit-tested `src/lib/backoff.ts`; replaces the old linear `WS_RECONNECT_DELAY_MS * attempt`. Jitter de-syncs the thundering herd of overlays reconnecting after a rolling deploy. (item #2)
- **Persist the attempt counter to `chrome.storage.session`** — an MV3 worker evicted mid-outage now resumes the existing backoff instead of restarting at attempt 0 and hammering the server on wake. (item #6)
- **Reconnecting badge** — orange `↻` + tooltip "AllChat — reconnecting…" instead of the ambiguous cleared badge.

## Explicitly NOT in scope (batch B — needs server changes)
The code-1006 "not public" heuristic (needs structured `4403` close codes), the `server_instance_id`/`boot_epoch` handshake, and `?since=` watermark hardening (issue items #3/#4/#5). #543 stays open for those.

## Verification
- `tsc --noEmit` clean
- `vitest run`: **40/40** pass, incl. new `tests/unit/backoff.test.ts` (exp growth, 30s ceiling, jitter bounds)
- `webpack --mode production` build succeeds

No manifest version bump — releasing (bump + `v*` tag) is a separate deliberate step.